### PR TITLE
Add conditional rendering of message templates 

### DIFF
--- a/.nuget/packages.config
+++ b/.nuget/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="serilog-generator" version="1.0.7" />
+</packages>

--- a/sample/Serilog.Sinks.Splunk.Sample/IConfigure.cs
+++ b/sample/Serilog.Sinks.Splunk.Sample/IConfigure.cs
@@ -1,0 +1,7 @@
+namespace Serilog.Sinks.Splunk.Sample
+{
+    internal interface IConfigure
+    {
+        void Configure();
+    }
+}

--- a/sample/Serilog.Sinks.Splunk.Sample/Program.cs
+++ b/sample/Serilog.Sinks.Splunk.Sample/Program.cs
@@ -10,12 +10,23 @@ namespace Serilog.Sinks.Splunk.Sample
         {
             Log.Logger = new LoggerConfiguration()
                 .WriteTo.LiterateConsole()
-                .WriteTo.SplunkViaTcp("127.0.0.1", 10001)
+                .WriteTo.SplunkViaTcp("127.0.0.1", 10001, renderTemplate:true)
                 .CreateLogger();
 
-            Log.Information("Just another test");
+            var person = new Person() {DateOfBirth = DateTime.Now.AddYears(-30), FirstName = "Joe", Surname = "Bloggs"};
+
+            Log.Information("Just another test {@person}", person);
 
             Console.ReadLine();
         }
     }
+
+    internal class Person
+    {
+        public string FirstName { get; set; }
+        public string Surname { get; set; }
+        public DateTime DateOfBirth { get; set; }
+
+    }
+
 }

--- a/sample/Serilog.Sinks.Splunk.Sample/Serilog.Sinks.Splunk.Sample.csproj
+++ b/sample/Serilog.Sinks.Splunk.Sample/Serilog.Sinks.Splunk.Sample.csproj
@@ -33,11 +33,16 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Serilog">
-      <HintPath>..\..\packages\Serilog.1.5.5\lib\net45\Serilog.dll</HintPath>
+    <Reference Include="Serilog, Version=1.5.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Serilog.1.5.6\lib\net45\Serilog.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="Serilog.FullNetFx">
-      <HintPath>..\..\packages\Serilog.1.5.5\lib\net45\Serilog.FullNetFx.dll</HintPath>
+    <Reference Include="serilog-generator">
+      <HintPath>..\..\packages\serilog-generator.1.0.7\tools\serilog-generator.exe</HintPath>
+    </Reference>
+    <Reference Include="Serilog.FullNetFx, Version=1.5.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Serilog.1.5.6\lib\net45\Serilog.FullNetFx.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Serilog.Sinks.Literate">
       <HintPath>..\..\packages\Serilog.Sinks.Literate.1.0.6\lib\net45\Serilog.Sinks.Literate.dll</HintPath>
@@ -49,13 +54,19 @@
       <HintPath>..\..\packages\Splunk.Logging.Common.1.1.0\lib\net45\Splunk.Logging.Common.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="Sprache, Version=2.0.0.45, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Sprache.2.0.0.45\lib\portable-net4+netcore45+win8+wp8+sl5+MonoAndroid1+MonoTouch1\Sprache.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="IConfigure.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Stub.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config" />
@@ -65,10 +76,6 @@
     <ProjectReference Include="..\..\src\Serilog.Sinks.Splunk.FullNetFx\Serilog.Sinks.Splunk.FullNetFx.csproj">
       <Project>{17deed0f-f9cb-48fb-b4dc-53fb6aee64d7}</Project>
       <Name>Serilog.Sinks.Splunk.FullNetFx</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\..\src\Serilog.Sinks.Splunk\Serilog.Sinks.Splunk.csproj">
-      <Project>{1493abc3-811c-46c7-92ed-ceb7567fb588}</Project>
-      <Name>Serilog.Sinks.Splunk</Name>
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/sample/Serilog.Sinks.Splunk.Sample/Stub.cs
+++ b/sample/Serilog.Sinks.Splunk.Sample/Stub.cs
@@ -1,0 +1,31 @@
+using System.Collections.Concurrent;
+using System.Linq;
+using Serilog.Generator.Actors;
+using Serilog.Generator.Model;
+
+namespace Serilog.Sinks.Splunk.Sample
+{
+    internal class Stub
+    {
+        public void Run()
+        {
+            const int initialCustomers = 1;
+
+            Log.Information("Simulation starting with {InitialCustomers} initial customers...", initialCustomers);
+
+            var catalog = new Catalog();
+
+            var customers = new ConcurrentBag<Customer>(Enumerable.Range(0, initialCustomers)
+                .Select(_ => new Customer(catalog)));
+
+            var traffic = new TrafficReferral(customers, catalog);
+            var admin = new Administrator(catalog);
+
+            foreach (var c in customers)
+                c.Start();
+
+            admin.Start();
+            traffic.Start();
+        }
+    }
+}

--- a/sample/Serilog.Sinks.Splunk.Sample/packages.config
+++ b/sample/Serilog.Sinks.Splunk.Sample/packages.config
@@ -1,8 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Serilog" version="1.5.5" targetFramework="net451" />
+  <package id="Serilog" version="1.5.6" targetFramework="net451" />
   <package id="Serilog.Sinks.Literate" version="1.0.6" targetFramework="net451" />
   <package id="Splunk.Client" version="2.1.2" targetFramework="net451" />
   <package id="Splunk.Logging.Common" version="1.1.0" targetFramework="net451" />
-  
+  <package id="Sprache" version="2.0.0.45" targetFramework="net451" />
+  <package id="serilog-generator" version="1.0.7" />
 </packages>

--- a/serilog-sinks-splunk.sln
+++ b/serilog-sinks-splunk.sln
@@ -21,6 +21,11 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Sample", "Sample", "{EBB6CE
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Serilog.Sinks.Splunk.Sample", "sample\Serilog.Sinks.Splunk.Sample\Serilog.Sinks.Splunk.Sample.csproj", "{F0B0E4EF-CF01-46FC-A64C-FE3528F14238}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{B16AD407-36C8-4286-A3E9-CACEBF359731}"
+	ProjectSection(SolutionItems) = preProject
+		.nuget\packages.config = .nuget\packages.config
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/src/Serilog.Sinks.Splunk.FullNetFx/LoggerConfigurationSplunkExtensions.cs
+++ b/src/Serilog.Sinks.Splunk.FullNetFx/LoggerConfigurationSplunkExtensions.cs
@@ -34,7 +34,8 @@ namespace Serilog
         /// <param name="batchInterval"></param>
         /// <param name="restrictedToMinimumLevel">The minimum log event level required in order to write an event to the sink.</param>
         /// <param name="formatProvider">Supplies culture-specific formatting information, or null.</param>
-        /// <param name="batchSizeLimit"></param>
+        /// <param name="batchSizeLimit">The size of the batch prior to writing</param>
+        /// <param name="renderTemplate">If true, the message template will be rendered</param>
         /// <returns>Logger configuration, allowing configuration to continue.</returns>
         /// <exception cref="ArgumentNullException">A required parameter is null.</exception>
         /// <remarks>TODO: Add link to splunk configuration and wiki</remarks>
@@ -44,9 +45,10 @@ namespace Serilog
             int batchSizeLimit,
             TimeSpan batchInterval,
             LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
-            IFormatProvider formatProvider = null)
+            IFormatProvider formatProvider = null,
+             bool renderTemplate = true)
         {
-            var sink = new SplunkViaHttpSink(context, batchSizeLimit, batchInterval, formatProvider);
+            var sink = new SplunkViaHttpSink(context, batchSizeLimit, batchInterval, formatProvider, renderTemplate);
 
             return loggerConfiguration.Sink(sink, restrictedToMinimumLevel);
         }
@@ -56,15 +58,16 @@ namespace Serilog
         /// </summary>
         /// <param name="loggerConfiguration">The logger configuration.</param>
         /// <param name="context">The Splunk context to log to</param>
-        /// <param name="password"></param>
+        /// <param name="password">The password of the Splunk user</param>
         /// <param name="resourceNameSpace"></param>
         /// <param name="transmitterArgs"></param>
         /// <param name="batchSizeLimit">The size of the batch prior to logging</param>
         /// <param name="batchInterval">The interval on which to log via http</param>
         /// <param name="restrictedToMinimumLevel">The minimum log event level required in order to write an event to the sink.</param>
         /// <param name="formatProvider">Supplies culture-specific formatting information, or null.</param>
-        /// <param name="index"></param>
-        /// <param name="userName"></param>
+        /// <param name="index">The name of the Splunk index</param>
+        /// <param name="userName">The name of the Splunk user</param>
+        /// <param name="renderTemplate">If ture, the message template is rendered</param>
         /// <returns>Logger configuration, allowing configuration to continue.</returns>
         /// <exception cref="ArgumentNullException">A required parameter is null.</exception>
         /// <remarks>TODO: Add link to splunk configuration and wiki</remarks>
@@ -79,7 +82,8 @@ namespace Serilog
             Namespace resourceNameSpace,
             TransmitterArgs transmitterArgs,
             LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
-            IFormatProvider formatProvider = null)
+            IFormatProvider formatProvider = null,
+             bool renderTemplate = true)
         {
             var sink = new SplunkViaHttpSink(new SplunkContext(context, index, userName, password, resourceNameSpace, transmitterArgs), batchSizeLimit,batchInterval, formatProvider);
 
@@ -94,6 +98,7 @@ namespace Serilog
         /// <param name="port">The UDP port</param>
         /// <param name="restrictedToMinimumLevel">The minimum log event level required in order to write an event to the sink.</param>
         /// <param name="formatProvider">Supplies culture-specific formatting information, or null.</param>
+        /// <param name="renderTemplate">If ture, the message template will be rendered</param>
         /// <returns></returns>
         /// <remarks>TODO: Add link to splunk configuration and wiki</remarks>
         public static LoggerConfiguration SplunkViaUdp(
@@ -101,9 +106,10 @@ namespace Serilog
             string host,
             int port,
             LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
-            IFormatProvider formatProvider = null)
+            IFormatProvider formatProvider = null,
+            bool renderTemplate = true)
         {
-            var sink = new SplunkViaUdpSink(host, port, formatProvider);
+            var sink = new SplunkViaUdpSink(host, port, formatProvider, renderTemplate);
 
             return loggerConfiguration.Sink(sink, restrictedToMinimumLevel);
         }
@@ -117,16 +123,18 @@ namespace Serilog
         /// <param name="port">The UDP port</param>
         /// <param name="restrictedToMinimumLevel">The minimum log event level required in order to write an event to the sink.</param>
         /// <param name="formatProvider">Supplies culture-specific formatting information, or null.</param>
-        /// <returns></returns>
+        /// <param name="renderTemplate">If ture, the message template is rendered</param>
+        /// <returns>The logger configuration</returns>
         /// <remarks>TODO: Add link to splunk configuration and wiki</remarks>
         public static LoggerConfiguration SplunkViaUdp(
             this LoggerSinkConfiguration loggerConfiguration,
             IPAddress hostAddresss,
             int port,
             LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
-            IFormatProvider formatProvider = null)
+            IFormatProvider formatProvider = null,
+            bool renderTemplate = true)
         {
-            var sink = new SplunkViaUdpSink(hostAddresss, port, formatProvider);
+            var sink = new SplunkViaUdpSink(hostAddresss, port, formatProvider, renderTemplate);
 
             return loggerConfiguration.Sink(sink, restrictedToMinimumLevel);
         }
@@ -139,6 +147,7 @@ namespace Serilog
         /// <param name="port">The TCP port</param>
         /// <param name="restrictedToMinimumLevel">The minimum log event level required in order to write an event to the sink.</param>
         /// <param name="formatProvider">Supplies culture-specific formatting information, or null.</param>
+        /// <param name="renderTemplate">If true, the message template is rendered</param>
         /// <returns></returns>
         /// <remarks>TODO: Add link to splunk configuration and wiki</remarks>
         public static LoggerConfiguration SplunkViaTcp(
@@ -146,9 +155,10 @@ namespace Serilog
             IPAddress hostAddresss,
             int port,
             LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
-            IFormatProvider formatProvider = null)
+            IFormatProvider formatProvider = null,
+             bool renderTemplate = true)
         {
-            var sink = new SplunkViaTcpSink(hostAddresss, port, formatProvider);
+            var sink = new SplunkViaTcpSink(hostAddresss, port, formatProvider, renderTemplate);
 
             return loggerConfiguration.Sink(sink, restrictedToMinimumLevel);
         }
@@ -161,6 +171,7 @@ namespace Serilog
         /// <param name="port">The TCP port</param>
         /// <param name="restrictedToMinimumLevel">The minimum log event level required in order to write an event to the sink.</param>
         /// <param name="formatProvider">Supplies culture-specific formatting information, or null.</param>
+        /// <param name="renderTemplate">If ture, the message template is rendered</param>
         /// <returns></returns>
         /// <remarks>TODO: Add link to splunk configuration and wiki</remarks>
         public static LoggerConfiguration SplunkViaTcp(
@@ -168,9 +179,10 @@ namespace Serilog
             string host,
             int port,
             LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
-            IFormatProvider formatProvider = null)
+            IFormatProvider formatProvider = null,
+             bool renderTemplate = true)
         {
-            var sink = new SplunkViaTcpSink(host, port, formatProvider);
+            var sink = new SplunkViaTcpSink(host, port, formatProvider, renderTemplate);
 
             return loggerConfiguration.Sink(sink, restrictedToMinimumLevel);
         }

--- a/src/Serilog.Sinks.Splunk.FullNetFx/Serilog.Sinks.Splunk.FullNetFx.csproj
+++ b/src/Serilog.Sinks.Splunk.FullNetFx/Serilog.Sinks.Splunk.FullNetFx.csproj
@@ -65,6 +65,9 @@
     <Compile Include="..\Serilog.Sinks.Splunk\Sinks\Splunk\SplunkContext.cs">
       <Link>Sinks\Splunk\SplunkContext.cs</Link>
     </Compile>
+    <Compile Include="..\Serilog.Sinks.Splunk\Sinks\Splunk\SplunkJsonFormatter.cs">
+      <Link>Sinks\Splunk\SplunkJsonFormatter.cs</Link>
+    </Compile>
     <Compile Include="..\Serilog.Sinks.Splunk\Sinks\Splunk\SplunkViaHttpSink.cs">
       <Link>Sinks\Splunk\SplunkViaHttpSink.cs</Link>
     </Compile>

--- a/src/Serilog.Sinks.Splunk.FullNetFx/Sinks/Splunk/SplunkViaTcpSink.cs
+++ b/src/Serilog.Sinks.Splunk.FullNetFx/Sinks/Splunk/SplunkViaTcpSink.cs
@@ -38,16 +38,19 @@ namespace Serilog.Sinks.Splunk
         /// <param name="hostAddress">The Splunk Host</param>
         /// <param name="port">The UDP port configured in Splunk</param>
         /// <param name="formatProvider">Optional format provider</param>
+        /// <param name="renderTemplate">If true, the message template will be rendered</param>
+
         public SplunkViaTcpSink(
             IPAddress hostAddress,
             int port,
-            IFormatProvider formatProvider = null)
+            IFormatProvider formatProvider = null,
+            bool renderTemplate = true)
         {
             var reconnectionPolicy = new ExponentialBackoffTcpReconnectionPolicy();
 
             _writer = new TcpSocketWriter(hostAddress, port, reconnectionPolicy, 10000);
 
-            _jsonFormatter = new JsonFormatter(renderMessage: true, formatProvider: formatProvider);
+            _jsonFormatter = new SplunkJsonFormatter(renderMessage: true, formatProvider: formatProvider, renderTemplate: renderTemplate);
         }
 
         /// <summary>
@@ -56,17 +59,19 @@ namespace Serilog.Sinks.Splunk
         /// <param name="host">The Splunk Host</param>
         /// <param name="port">The UDP port configured in Splunk</param>
         /// <param name="formatProvider">Optional format provider</param>
+        /// <param name="renderTemplate">If true, the message template will be rendered</param>
         public SplunkViaTcpSink(
             string host,
             int port,
-            IFormatProvider formatProvider = null)
+            IFormatProvider formatProvider = null,
+            bool renderTemplate = true)
         {
             var reconnectionPolicy = new ExponentialBackoffTcpReconnectionPolicy();
             var ipAddress = IPAddress.Parse(host);
 
             _writer = new TcpSocketWriter(ipAddress, port, reconnectionPolicy, 10000);
 
-            _jsonFormatter = new JsonFormatter(renderMessage: true, formatProvider: formatProvider);
+            _jsonFormatter = new SplunkJsonFormatter(renderMessage: true, formatProvider: formatProvider, renderTemplate: renderTemplate);
         }
 
         /// <inheritdoc/>

--- a/src/Serilog.Sinks.Splunk.FullNetFx/Sinks/Splunk/SplunkViaUdpSink.cs
+++ b/src/Serilog.Sinks.Splunk.FullNetFx/Sinks/Splunk/SplunkViaUdpSink.cs
@@ -37,12 +37,13 @@ namespace Serilog.Sinks.Splunk
         /// <param name="hostAddress">The Splunk Host</param>
         /// <param name="port">The UDP port configured in Splunk</param>
         /// <param name="formatProvider">Optional format provider</param>
-        public SplunkViaUdpSink(IPAddress hostAddress, int port, IFormatProvider formatProvider = null)
+        /// <param name="renderTemplate">If true, the message template will be rendered</param>
+        public SplunkViaUdpSink(IPAddress hostAddress, int port, IFormatProvider formatProvider = null, bool renderTemplate = true)
         {
             _socket = new Socket(SocketType.Dgram, ProtocolType.Udp);
             _socket.Connect(hostAddress, port);
 
-            _jsonFormatter = new JsonFormatter(renderMessage: true, formatProvider: formatProvider);            
+            _jsonFormatter = new SplunkJsonFormatter(renderMessage: true, formatProvider: formatProvider, renderTemplate: renderTemplate);
         }
 
         /// <summary>

--- a/src/Serilog.Sinks.Splunk.FullNetFx/Sinks/Splunk/SplunkViaUdpSink.cs
+++ b/src/Serilog.Sinks.Splunk.FullNetFx/Sinks/Splunk/SplunkViaUdpSink.cs
@@ -28,8 +28,8 @@ namespace Serilog.Sinks.Splunk
     /// </summary>
     public class SplunkViaUdpSink : ILogEventSink, IDisposable
     {
-        Socket _socket;
-        JsonFormatter _jsonFormatter;
+        readonly Socket _socket;
+        readonly JsonFormatter _jsonFormatter;
 
         /// <summary>
         /// Creates an instance of the Splunk UDP Sink
@@ -52,12 +52,14 @@ namespace Serilog.Sinks.Splunk
         /// <param name="host">The Splunk Host</param>
         /// <param name="port">The UDP port configured in Splunk</param>
         /// <param name="formatProvider">Optional format provider</param>
-        public SplunkViaUdpSink(string host, int port, IFormatProvider formatProvider = null)
+        /// <param name="renderTemplate">If true, the message template is rendered</param>
+        public SplunkViaUdpSink(string host, int port, IFormatProvider formatProvider = null,
+             bool renderTemplate = true)
         {
             _socket = new Socket(SocketType.Dgram, ProtocolType.Udp);
             _socket.Connect(host, port);
 
-            _jsonFormatter = new JsonFormatter(renderMessage: true, formatProvider: formatProvider);
+            _jsonFormatter = new SplunkJsonFormatter(renderMessage: true, formatProvider: formatProvider, renderTemplate:renderTemplate);
         }
 
         /// <inheritdoc/>

--- a/src/Serilog.Sinks.Splunk/LoggerConfigurationSplunkExtensions.cs
+++ b/src/Serilog.Sinks.Splunk/LoggerConfigurationSplunkExtensions.cs
@@ -34,6 +34,7 @@ namespace Serilog
         /// <param name="batchInterval">The interval on which to log via http</param>
         /// <param name="restrictedToMinimumLevel">The minimum log event level required in order to write an event to the sink.</param>
         /// <param name="formatProvider">Supplies culture-specific formatting information, or null.</param>
+        /// <param name="renderTemplate">If true, the message template will be rendered</param>
         /// <returns>Logger configuration, allowing configuration to continue.</returns>
         /// <exception cref="ArgumentNullException">A required parameter is null.</exception>
         /// <remarks>TODO: Add link to splunk configuration and wiki</remarks>
@@ -43,9 +44,10 @@ namespace Serilog
             int batchSizeLimit,
             TimeSpan batchInterval,
             LogEventLevel restrictedToMinimumLevel = LogEventLevel.Debug,
-            IFormatProvider formatProvider = null)
+            IFormatProvider formatProvider = null,
+            bool renderTemplate = true)
         {
-            var sink = new SplunkViaHttpSink(context, batchSizeLimit, batchInterval, formatProvider);
+            var sink = new SplunkViaHttpSink(context, batchSizeLimit, batchInterval, formatProvider, renderTemplate);
 
             return loggerConfiguration.Sink(sink);
         }
@@ -64,13 +66,13 @@ namespace Serilog
         /// <param name="formatProvider">Supplies culture-specific formatting information, or null.</param>
         /// <param name="index"></param>
         /// <param name="userName"></param>
+        /// <param name="renderTemplate">If true, the message template will be rendered</param>
         /// <returns>Logger configuration, allowing configuration to continue.</returns>
         /// <exception cref="ArgumentNullException">A required parameter is null.</exception>
         /// <remarks>TODO: Add link to splunk configuration and wiki</remarks>
         public static LoggerConfiguration SplunkViaHttp(
             this LoggerSinkConfiguration loggerConfiguration,
             Context context,
-
             string index,
             string userName,
             string password,
@@ -79,9 +81,10 @@ namespace Serilog
             int batchSizeLimit,
             TimeSpan batchInterval,
             LogEventLevel restrictedToMinimumLevel = LogEventLevel.Debug,
-            IFormatProvider formatProvider = null)
+            IFormatProvider formatProvider = null,
+            bool renderTemplate = true)
         {
-            var sink = new SplunkViaHttpSink(new SplunkContext(context, index, userName, password, resourceNameSpace, transmitterArgs), batchSizeLimit, batchInterval, formatProvider);
+            var sink = new SplunkViaHttpSink(new SplunkContext(context, index, userName, password, resourceNameSpace, transmitterArgs), batchSizeLimit, batchInterval, formatProvider,renderTemplate);
 
             return loggerConfiguration.Sink(sink);
         }

--- a/src/Serilog.Sinks.Splunk/Serilog.Sinks.Splunk.csproj
+++ b/src/Serilog.Sinks.Splunk/Serilog.Sinks.Splunk.csproj
@@ -55,6 +55,7 @@
       <Link>Properties\CommonAssemblyInfo.cs</Link>
     </Compile>
     <Compile Include="Sinks\Splunk\SplunkContext.cs" />
+    <Compile Include="Sinks\Splunk\SplunkJsonFormatter.cs" />
     <Compile Include="Sinks\Splunk\SplunkViaHttpSink.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Serilog.Sinks.Splunk/Sinks/Splunk/SplunkJsonFormatter.cs
+++ b/src/Serilog.Sinks.Splunk/Sinks/Splunk/SplunkJsonFormatter.cs
@@ -1,0 +1,65 @@
+﻿// Copyright 2014 Serilog Contriutors
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.using System;
+
+using System;
+using System.IO;
+using Serilog.Formatting.Json;
+
+namespace Serilog.Sinks.Splunk
+{
+    /// <summary>
+    /// A json formatter to allow conditional rendering of properties
+    /// </summary>
+    public class SplunkJsonFormatter : JsonFormatter
+    {
+        private readonly bool _renderTemplate;
+
+        /// <summary>
+        /// Construct a <see cref="JsonFormatter"/>.
+        /// </summary>
+        /// <param name="omitEnclosingObject">If true, the properties of the event will be written to
+        /// the output without enclosing braces. Otherwise, if false, each event will be written as a well-formed
+        /// JSON object.</param>
+        /// <param name="closingDelimiter">A string that will be written after each log event is formatted.
+        /// If null, <see cref="Environment.NewLine"/> will be used. Ignored if <paramref name="omitEnclosingObject"/>
+        /// is true.</param>
+        /// <param name="renderMessage">If true, the message will be rendered and written to the output as a
+        /// property named RenderedMessage.</param>
+        /// <param name="formatProvider">Supplies culture-specific formatting information, or null.</param>
+        /// <param name="renderTemplate">If true, the template used will be rendered and written to the output as a property named MessageTemplate</param>
+        public SplunkJsonFormatter(
+            bool omitEnclosingObject = false,
+            string closingDelimiter = null,
+            bool renderMessage = false,
+            IFormatProvider formatProvider = null,
+            bool renderTemplate = true) 
+            :base(omitEnclosingObject,closingDelimiter,renderMessage,formatProvider)
+        {
+            _renderTemplate = renderTemplate;
+        }
+
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="template"></param>
+        /// <param name="delim"></param>
+        /// <param name="output"></param>
+        protected override void WriteMessageTemplate(string template, ref string delim, TextWriter output)
+        {
+            if(_renderTemplate)
+                base.WriteMessageTemplate(template, ref delim, output);
+        }
+    }
+}


### PR DESCRIPTION
Aims to address issue [#424](https://github.com/serilog/serilog/issues/424)

- Adds new JSONFormatter
- Overload on three sinks to allow for conditional rendering of templates.  e.g. `renderTemplate = false`