### PR TITLE
Send LogEvent timestamp as "time" in Http Collector json

### DIFF
--- a/src/Serilog.Sinks.Splunk.FullNetFx/Serilog.Sinks.Splunk.FullNetFx.csproj
+++ b/src/Serilog.Sinks.Splunk.FullNetFx/Serilog.Sinks.Splunk.FullNetFx.csproj
@@ -65,6 +65,9 @@
     <Compile Include="..\Serilog.Sinks.Splunk\LoggerConfigurationSplunkPCLExtensions.cs">
       <Link>LoggerConfigurationSplunkPCLExtensions.cs</Link>
     </Compile>
+    <Compile Include="..\Serilog.Sinks.Splunk\Sinks\Splunk\Epoch.cs">
+      <Link>Sinks\Splunk\Epoch.cs</Link>
+    </Compile>
     <Compile Include="..\Serilog.Sinks.Splunk\Sinks\Splunk\EventCollectorClient.cs">
       <Link>Sinks\Splunk\EventCollectorClient.cs</Link>
     </Compile>

--- a/src/Serilog.Sinks.Splunk/Serilog.Sinks.Splunk.csproj
+++ b/src/Serilog.Sinks.Splunk/Serilog.Sinks.Splunk.csproj
@@ -54,6 +54,7 @@
     <Compile Include="..\..\assets\CommonAssemblyInfo.cs">
       <Link>Properties\CommonAssemblyInfo.cs</Link>
     </Compile>
+    <Compile Include="Sinks\Splunk\Epoch.cs" />
     <Compile Include="Sinks\Splunk\EventCollectorClient.cs" />
     <Compile Include="Sinks\Splunk\EventCollectorRequest.cs" />
     <Compile Include="Sinks\Splunk\RepeatAction.cs" />

--- a/src/Serilog.Sinks.Splunk/Sinks/Splunk/Epoch.cs
+++ b/src/Serilog.Sinks.Splunk/Sinks/Splunk/Epoch.cs
@@ -1,0 +1,20 @@
+﻿namespace Serilog.Sinks.Splunk
+{
+    using System;
+
+    internal static class EpochExtensions
+    {
+        private static DateTimeOffset Epoch = new DateTimeOffset(1970,1,1,0,0,0,TimeSpan.Zero);
+
+        public static double ToEpoch(this DateTimeOffset value)
+        {
+            // From Splunk HTTP Collector Protocol
+            // The default time format is epoch time format, in the format <sec>.<ms>. 
+            // For example, 1433188255.500 indicates 1433188255 seconds and 500 milliseconds after epoch, 
+            // or Monday, June 1, 2015, at 7:50:55 PM GMT.
+            // See: http://dev.splunk.com/view/SP-CAAAE6P
+
+            return Math.Round((value - Epoch).TotalSeconds, 3, MidpointRounding.AwayFromZero);
+        }
+    }
+}

--- a/src/Serilog.Sinks.Splunk/Sinks/Splunk/EventCollectorRequest.cs
+++ b/src/Serilog.Sinks.Splunk/Sinks/Splunk/EventCollectorRequest.cs
@@ -8,7 +8,7 @@ namespace Serilog.Sinks.Splunk
     {
         private string _payload;
 
-        internal SplunkEvent(string logEvent, string source, string sourceType, string host, string index)
+        internal SplunkEvent(string logEvent, string source, string sourceType, string host, string index, double time)
         {
             _payload = string.Empty;
 
@@ -30,6 +30,11 @@ namespace Serilog.Sinks.Splunk
             if (!string.IsNullOrWhiteSpace(index))
             {
                 jsonPayLoad = jsonPayLoad + @",""index"":""" + index + @"""";
+            }
+
+            if (time > 0)
+            {
+                jsonPayLoad = jsonPayLoad + @",""time"":" + time;
             }
 
             jsonPayLoad = jsonPayLoad + "}";

--- a/src/Serilog.Sinks.Splunk/Sinks/Splunk/EventCollectorSink.cs
+++ b/src/Serilog.Sinks.Splunk/Sinks/Splunk/EventCollectorSink.cs
@@ -176,8 +176,8 @@ namespace Serilog.Sinks.Splunk
                 _jsonFormatter.Format(logEvent, sw);
 
                 var serialisedEvent = sw.ToString();
-
-                var splunkEvent = new SplunkEvent(serialisedEvent, _source, _sourceType, _host, _index);
+                
+                var splunkEvent = new SplunkEvent(serialisedEvent, _source, _sourceType, _host, _index, logEvent.Timestamp.ToEpoch());
 
                 allEvents = $"{allEvents}{splunkEvent.Payload}";
             }


### PR DESCRIPTION
Per splunk documentation, the log event time (that will later be parsed as
the timestamp of the event by splunk) should be sent in the `time`
property of the event metadata envelope and should be formated as
epoch <sec>.<ms>

Sending the event timestamp in in the pre-defined `time` metadata property
is important as it alleviates the event processing demands in splunk. As stated in Splunk Docs:

>The HTTP Event Collector endpoint extracts the events from the HTTP
>request and parses them before sending them to indexers. Because the
>event data format, as described in this topic, is pre-determined, Splunk
>Enterprise is able to parse your data quickly, and then sends it to be
>indexed. This results in improved data throughput and reduced event
>processing time compared to other methods of getting data in.

For more information, see Http Collector Protocol documentation
(http://dev.splunk.com/view/SP-CAAAE6P)