### PR TITLE
Fix JSON output bug: Apply culture invariant to time

### DIFF
--- a/src/Serilog.Sinks.Splunk/Sinks/Splunk/EventCollectorRequest.cs
+++ b/src/Serilog.Sinks.Splunk/Sinks/Splunk/EventCollectorRequest.cs
@@ -14,6 +14,7 @@
 
 
 using System;
+using System.Globalization;
 using System.Net.Http;
 using System.Text;
 
@@ -49,7 +50,7 @@ namespace Serilog.Sinks.Splunk
 
             if (time > 0)
             {
-                jsonPayLoad = jsonPayLoad + @",""time"":" + time;
+                jsonPayLoad = jsonPayLoad + @",""time"":" +  time.ToString(CultureInfo.InvariantCulture);
             }
 
             jsonPayLoad = jsonPayLoad + "}";


### PR DESCRIPTION
In case of an other culture, the json will be wrong formated with a comma:
`{
        ...
        "time": 1234567,89
}`
To fix this time.ToString(CultureInfo.InvariantCulture) is required.