### PR TITLE
Update build and test infrastructure; move to standalone JSON formatter

### DIFF
--- a/Build.ps1
+++ b/Build.ps1
@@ -1,16 +1,51 @@
+echo "build: Build started"
+
 Push-Location $PSScriptRoot
 
-if(Test-Path .\artifacts) { Remove-Item .\artifacts -Force -Recurse }
+if(Test-Path .\artifacts) {
+	echo "build: Cleaning .\artifacts"
+	Remove-Item .\artifacts -Force -Recurse
+}
 
-& dotnet restore
+& dotnet restore --no-cache
 
-$revision = @{ $true = $env:APPVEYOR_BUILD_NUMBER; $false = 1 }[$env:APPVEYOR_BUILD_NUMBER -ne $NULL];
+$branch = @{ $true = $env:APPVEYOR_REPO_BRANCH; $false = $(git symbolic-ref --short -q HEAD) }[$env:APPVEYOR_REPO_BRANCH -ne $NULL];
+$revision = @{ $true = "{0:00000}" -f [convert]::ToInt32("0" + $env:APPVEYOR_BUILD_NUMBER, 10); $false = "local" }[$env:APPVEYOR_BUILD_NUMBER -ne $NULL];
+$suffix = @{ $true = ""; $false = "$($branch.Substring(0, [math]::Min(10,$branch.Length)))-$revision"}[$branch -eq "master" -and $revision -ne "local"]
 
-Push-Location src/Serilog.Sinks.Splunk
+echo "build: Version suffix is $suffix"
 
-& dotnet pack -c Release -o ..\..\.\artifacts --version-suffix=$revision
-if($LASTEXITCODE -ne 0) { exit 1 }    
+foreach ($src in ls src/*) {
+    Push-Location $src
 
+	echo "build: Packaging project in $src"
 
-Pop-Location
+    & dotnet pack -c Release -o ..\..\artifacts --version-suffix=$suffix
+    if($LASTEXITCODE -ne 0) { exit 1 }    
+
+    Pop-Location
+}
+
+foreach ($test in ls test/*.PerformanceTests) {
+    Push-Location $test
+
+	echo "build: Building performance test project in $test"
+
+    & dotnet build -c Release
+    if($LASTEXITCODE -ne 0) { exit 2 }
+
+    Pop-Location
+}
+
+foreach ($test in ls test/*.Tests) {
+    Push-Location $test
+
+	echo "build: Testing project in $test"
+
+    & dotnet test -c Release
+    if($LASTEXITCODE -ne 0) { exit 3 }
+
+    Pop-Location
+}
+
 Pop-Location

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,10 +19,10 @@ deploy:
     secure: nvZ/z+pMS91b3kG4DgfES5AcmwwGoBYQxr9kp4XiJHj25SAlgdIxFx++1N0lFH2x
   skip_symbols: true
   on:
-    branch: master
+    branch: /^(master|dev)$/
 - provider: GitHub
   auth_token:
-    secure: ggZTqqV1z0xecDoQbeoy3A7xikShCt9FWZIGp95dG9Fo0p5RAT9oGU0ZekHfUIwk
+    secure: p4LpVhBKxGS5WqucHxFQ5c7C8cP74kbNB0Z8k9Oxx/PMaDQ1+ibmoexNqVU5ZlmX
   artifact: /Serilog.*\.nupkg/
   tag: v$(appveyor_build_version)
   on:

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
-﻿{
+{
   "projects": [ "src", "test" ],
   "sdk": {
-    "version": "1.0.0-preview1-002702"
+    "version": "1.0.0-preview2-003121"
   }
 }

--- a/serilog-sinks-splunk.sln
+++ b/serilog-sinks-splunk.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.24720.0
+VisualStudioVersion = 14.0.25420.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{7A774CBB-A6E9-4854-B4DB-4CF860B0C1C5}"
 EndProject
@@ -25,6 +25,10 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "sample", "sample", "{1C75E4
 EndProject
 Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Sample", "src\sample\Sample.xproj", "{17497155-5D94-45DF-81D9-BD960E8CF217}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "test", "test", "{B9451AD8-09B9-4C09-A152-FBAE24806614}"
+EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Serilog.Sinks.Splunk.Tests", "test\Serilog.Sinks.Splunk.Tests\Serilog.Sinks.Splunk.Tests.xproj", "{3C2D8E01-5580-426A-BDD9-EC59CD98E618}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -39,6 +43,10 @@ Global
 		{17497155-5D94-45DF-81D9-BD960E8CF217}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{17497155-5D94-45DF-81D9-BD960E8CF217}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{17497155-5D94-45DF-81D9-BD960E8CF217}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3C2D8E01-5580-426A-BDD9-EC59CD98E618}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3C2D8E01-5580-426A-BDD9-EC59CD98E618}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3C2D8E01-5580-426A-BDD9-EC59CD98E618}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3C2D8E01-5580-426A-BDD9-EC59CD98E618}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -46,5 +54,6 @@ Global
 	GlobalSection(NestedProjects) = preSolution
 		{32CF915C-3ECD-496C-8FDB-1214581274A6} = {7A774CBB-A6E9-4854-B4DB-4CF860B0C1C5}
 		{17497155-5D94-45DF-81D9-BD960E8CF217} = {1C75E4A9-4CB1-497C-AD17-B438882051A1}
+		{3C2D8E01-5580-426A-BDD9-EC59CD98E618} = {B9451AD8-09B9-4C09-A152-FBAE24806614}
 	EndGlobalSection
 EndGlobal

--- a/src/Serilog.Sinks.Splunk/Properties/AssemblyInfo.cs
+++ b/src/Serilog.Sinks.Splunk/Properties/AssemblyInfo.cs
@@ -2,3 +2,5 @@
 using System.Runtime.CompilerServices;
 
 [assembly: AssemblyVersion("2.0.0.0")]
+
+[assembly: InternalsVisibleTo("Serilog.Sinks.Splunk.Tests")]

--- a/src/Serilog.Sinks.Splunk/Sinks/Splunk/EventCollectorRequest.cs
+++ b/src/Serilog.Sinks.Splunk/Sinks/Splunk/EventCollectorRequest.cs
@@ -14,55 +14,11 @@
 
 
 using System;
-using System.Globalization;
 using System.Net.Http;
 using System.Text;
 
 namespace Serilog.Sinks.Splunk
 {
-    internal class SplunkEvent
-    {
-        private string _payload;
-
-        internal SplunkEvent(string logEvent, string source, string sourceType, string host, string index, double time)
-        {
-            _payload = string.Empty;
-
-            var jsonPayLoad = @"{""event"":" + logEvent
-            .Replace("\r\n", string.Empty);
-
-            if (!string.IsNullOrWhiteSpace(source))
-            {
-                jsonPayLoad = jsonPayLoad + @",""source"":""" + source + @"""";
-            }
-            if (!string.IsNullOrWhiteSpace(sourceType))
-            {
-                jsonPayLoad = jsonPayLoad + @",""sourceType"":""" + sourceType + @"""";
-            }
-            if (!string.IsNullOrWhiteSpace(host))
-            {
-                jsonPayLoad = jsonPayLoad + @",""host"":""" + host + @"""";
-            }
-            if (!string.IsNullOrWhiteSpace(index))
-            {
-                jsonPayLoad = jsonPayLoad + @",""index"":""" + index + @"""";
-            }
-
-            if (time > 0)
-            {
-                jsonPayLoad = jsonPayLoad + @",""time"":" +  time.ToString(CultureInfo.InvariantCulture);
-            }
-
-            jsonPayLoad = jsonPayLoad + "}";
-            _payload = jsonPayLoad;
-        }
-
-        public string Payload
-        {
-            get { return _payload; }
-        }
-    }
-
     internal class EventCollectorRequest : HttpRequestMessage
     {
         internal EventCollectorRequest(string splunkHost, string jsonPayLoad, string uri ="services/collector")

--- a/src/Serilog.Sinks.Splunk/Sinks/Splunk/EventCollectorSink.cs
+++ b/src/Serilog.Sinks.Splunk/Sinks/Splunk/EventCollectorSink.cs
@@ -18,7 +18,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Net;
-using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using Serilog.Core;
@@ -33,20 +32,11 @@ namespace Serilog.Sinks.Splunk
     public class EventCollectorSink : ILogEventSink, IDisposable
     {
         private readonly string _splunkHost;
-        private readonly string _eventCollectorToken;
-        private readonly string _source;
-        private readonly string _sourceType;
-        private readonly string _host;
-        private readonly string _index;
         private readonly string _uriPath;
         private readonly int _batchSizeLimitLimit;
         private readonly SplunkJsonFormatter _jsonFormatter;
         private readonly ConcurrentQueue<LogEvent> _queue;
         private readonly EventCollectorClient _httpClient;
-        private const string DefaultSource = "";
-        private const string DefaultSourceType = "";
-        private const string DefaultHost = "";
-        private const string DefaultIndex = "";
 
         /// <summary>
         /// Taken from Splunk.Logging.Common
@@ -56,7 +46,7 @@ namespace Serilog.Sinks.Splunk
             HttpStatusCode.Forbidden,
             HttpStatusCode.MethodNotAllowed,
             HttpStatusCode.BadRequest
-        }; 
+        };
 
         /// <summary>
         /// Creates a new instance of the sink
@@ -73,24 +63,16 @@ namespace Serilog.Sinks.Splunk
             int batchIntervalInSeconds = 5,
             int batchSizeLimit = 100,
             IFormatProvider formatProvider = null,
-            bool renderTemplate = true
-            )
+            bool renderTemplate = true)
+            : this(
+                splunkHost,
+                eventCollectorToken,
+                null, null, null, null, null, 
+                batchIntervalInSeconds, 
+                batchSizeLimit,
+                formatProvider,
+                renderTemplate)
         {
-            _splunkHost = splunkHost;
-            _eventCollectorToken = eventCollectorToken;
-            _queue = new ConcurrentQueue<LogEvent>();
-            _jsonFormatter = new SplunkJsonFormatter(renderMessage: true, formatProvider: formatProvider, renderTemplate: renderTemplate);
-            _batchSizeLimitLimit = batchSizeLimit;
-
-            var batchInterval = TimeSpan.FromSeconds(batchIntervalInSeconds);
-            _httpClient = new EventCollectorClient(_eventCollectorToken);
-            
-            var cancellationToken = new CancellationToken();
-            
-            RepeatAction.OnInterval(
-                batchInterval,
-                async () => await ProcessQueue(),
-                cancellationToken);
         } 
 
         /// <summary>
@@ -118,19 +100,23 @@ namespace Serilog.Sinks.Splunk
             int batchIntervalInSeconds,
             int batchSizeLimit,
             IFormatProvider formatProvider = null,
-            bool renderTemplate = true
-            ) : this(splunkHost,
-                eventCollectorToken,
-                batchIntervalInSeconds,
-                batchSizeLimit,
-                formatProvider,
-                renderTemplate)
+            bool renderTemplate = true)
         {
-            _source = source;
-            _sourceType = sourceType;
-            _host = host;
-            _index = index;
             _uriPath = uriPath;
+            _splunkHost = splunkHost;
+            _queue = new ConcurrentQueue<LogEvent>();
+            _jsonFormatter = new SplunkJsonFormatter(renderTemplate, formatProvider, source, sourceType, host, index);
+            _batchSizeLimitLimit = batchSizeLimit;
+
+            var batchInterval = TimeSpan.FromSeconds(batchIntervalInSeconds);
+            _httpClient = new EventCollectorClient(eventCollectorToken);
+
+            var cancellationToken = new CancellationToken();
+
+            RepeatAction.OnInterval(
+                batchInterval,
+                async () => await ProcessQueue(),
+                cancellationToken);
         }
 
         /// <summary>
@@ -175,21 +161,14 @@ namespace Serilog.Sinks.Splunk
 
         private async Task Send(IEnumerable<LogEvent> events)
         {
-            string allEvents = string.Empty;
+            var allEvents = new StringWriter();
 
             foreach (var logEvent in events)
             {
-                var sw = new StringWriter();
-                _jsonFormatter.Format(logEvent, sw);
-
-                var serialisedEvent = sw.ToString();
-
-                var splunkEvent = new SplunkEvent(serialisedEvent, _source, _sourceType, _host, _index, logEvent.Timestamp.ToEpoch());
-
-                allEvents = $"{allEvents}{splunkEvent.Payload}";
+                _jsonFormatter.Format(logEvent, allEvents);
             }
 
-            var request = new EventCollectorRequest(_splunkHost, allEvents, _uriPath);
+            var request = new EventCollectorRequest(_splunkHost, allEvents.ToString(), _uriPath);
             var response = await _httpClient.SendAsync(request);
 
             if (response.IsSuccessStatusCode)

--- a/src/Serilog.Sinks.Splunk/Sinks/Splunk/SplunkJsonFormatter.cs
+++ b/src/Serilog.Sinks.Splunk/Sinks/Splunk/SplunkJsonFormatter.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014 Serilog Contriutors
+﻿// Copyright 2016 Serilog Contributors
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -10,56 +10,96 @@
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
-// limitations under the License.using System;
+// limitations under the License.
 
 using System;
+using System.Collections.Generic;
 using System.IO;
+using Serilog.Events;
+using Serilog.Formatting;
 using Serilog.Formatting.Json;
 
 namespace Serilog.Sinks.Splunk
 {
     /// <summary>
-    /// A json formatter to allow conditional rendering of properties
+    /// Renders log events into a default JSON format for consumption by Splunk.
     /// </summary>
-    public class SplunkJsonFormatter : JsonFormatter
+    class SplunkJsonFormatter : ITextFormatter
     {
-        private readonly bool _renderTemplate;
+        static readonly JsonValueFormatter ValueFormatter = new JsonValueFormatter();
+
+        readonly bool _renderTemplate;
+        readonly bool _renderMessage;
+        readonly IFormatProvider _formatProvider;
 
         /// <summary>
-        /// Construct a <see cref="JsonFormatter"/>.
+        /// Construct a <see cref="SplunkJsonFormatter"/>.
         /// </summary>
-        /// <param name="omitEnclosingObject">If true, the properties of the event will be written to
-        /// the output without enclosing braces. Otherwise, if false, each event will be written as a well-formed
-        /// JSON object.</param>
-        /// <param name="closingDelimiter">A string that will be written after each log event is formatted.
-        /// If null, <see cref="Environment.NewLine"/> will be used. Ignored if <paramref name="omitEnclosingObject"/>
-        /// is true.</param>
         /// <param name="renderMessage">If true, the message will be rendered and written to the output as a
         /// property named RenderedMessage.</param>
         /// <param name="formatProvider">Supplies culture-specific formatting information, or null.</param>
         /// <param name="renderTemplate">If true, the template used will be rendered and written to the output as a property named MessageTemplate</param>
         public SplunkJsonFormatter(
-            bool omitEnclosingObject = false,
-            string closingDelimiter = null,
+            bool renderTemplate = true,
             bool renderMessage = false,
-            IFormatProvider formatProvider = null,
-            bool renderTemplate = true) 
-            :base(omitEnclosingObject,closingDelimiter,renderMessage,formatProvider)
+            IFormatProvider formatProvider = null)
         {
             _renderTemplate = renderTemplate;
+            _renderMessage = renderMessage;
+            _formatProvider = formatProvider;
         }
 
-
-        /// <summary>
-        /// Writes the message with or without the message template
-        /// </summary>
-        /// <param name="template"></param>
-        /// <param name="delim"></param>
-        /// <param name="output"></param>
-        protected override void WriteMessageTemplate(string template, ref string delim, TextWriter output)
+        public void Format(LogEvent logEvent, TextWriter output)
         {
-            if(_renderTemplate)
-                base.WriteMessageTemplate(template, ref delim, output);
+            if (logEvent == null) throw new ArgumentNullException(nameof(logEvent));
+            if (output == null) throw new ArgumentNullException(nameof(output));
+
+            output.Write("{\"Timestamp\":\"");
+            output.Write(logEvent.Timestamp.ToString("o"));
+            output.Write("\",\"Level\":\"");
+            output.Write(logEvent.Level);
+
+            if (_renderTemplate)
+            {
+                output.Write("\",\"MessageTemplate\":");
+                JsonValueFormatter.WriteQuotedJsonString(logEvent.MessageTemplate.Text, output);
+            }
+
+            if (_renderMessage)
+            {
+                output.Write("\",\"RenderedMessage\":");
+                JsonValueFormatter.WriteQuotedJsonString(logEvent.RenderMessage(_formatProvider), output);
+            }
+
+            if (logEvent.Exception != null)
+            {
+                output.Write(",\"Exception\":");
+                JsonValueFormatter.WriteQuotedJsonString(logEvent.Exception.ToString(), output);
+            }
+
+            if (logEvent.Properties.Count != 0)
+                WriteProperties(logEvent.Properties, output);
+
+            output.Write('}');
+            output.WriteLine();
+        }
+
+        static void WriteProperties(IReadOnlyDictionary<string, LogEventPropertyValue> properties, TextWriter output)
+        {
+            output.Write(",\"Properties\":{");
+
+            var precedingDelimiter = "";
+            foreach (var property in properties)
+            {
+                output.Write(precedingDelimiter);
+                precedingDelimiter = ",";
+
+                JsonValueFormatter.WriteQuotedJsonString(property.Key, output);
+                output.Write(':');
+                ValueFormatter.Format(property.Value, output);
+            }
+
+            output.Write('}');
         }
     }
 }

--- a/src/Serilog.Sinks.Splunk/Sinks/Splunk/SplunkJsonFormatter.cs
+++ b/src/Serilog.Sinks.Splunk/Sinks/Splunk/SplunkJsonFormatter.cs
@@ -67,7 +67,7 @@ namespace Serilog.Sinks.Splunk
 
             if (_renderMessage)
             {
-                output.Write("\",\"RenderedMessage\":");
+                output.Write(",\"RenderedMessage\":");
                 JsonValueFormatter.WriteQuotedJsonString(logEvent.RenderMessage(_formatProvider), output);
             }
 

--- a/src/Serilog.Sinks.Splunk/Sinks/Splunk/SplunkJsonFormatter.cs
+++ b/src/Serilog.Sinks.Splunk/Sinks/Splunk/SplunkJsonFormatter.cs
@@ -49,6 +49,7 @@ namespace Serilog.Sinks.Splunk
             _formatProvider = formatProvider;
         }
 
+        /// <inheritdoc/>
         public void Format(LogEvent logEvent, TextWriter output)
         {
             if (logEvent == null) throw new ArgumentNullException(nameof(logEvent));

--- a/src/Serilog.Sinks.Splunk/Sinks/Splunk/SplunkJsonFormatter.cs
+++ b/src/Serilog.Sinks.Splunk/Sinks/Splunk/SplunkJsonFormatter.cs
@@ -24,7 +24,7 @@ namespace Serilog.Sinks.Splunk
     /// <summary>
     /// Renders log events into a default JSON format for consumption by Splunk.
     /// </summary>
-    class SplunkJsonFormatter : ITextFormatter
+    public class SplunkJsonFormatter : ITextFormatter
     {
         static readonly JsonValueFormatter ValueFormatter = new JsonValueFormatter();
 

--- a/src/Serilog.Sinks.Splunk/Sinks/Splunk/SplunkJsonFormatter.cs
+++ b/src/Serilog.Sinks.Splunk/Sinks/Splunk/SplunkJsonFormatter.cs
@@ -109,7 +109,7 @@ namespace Serilog.Sinks.Splunk
 
             if (_renderTemplate)
             {
-                output.Write("\",\"MessageTemplate\":");
+                output.Write(",\"MessageTemplate\":");
                 JsonValueFormatter.WriteQuotedJsonString(logEvent.MessageTemplate.Text, output);
             }
 

--- a/src/Serilog.Sinks.Splunk/Sinks/Splunk/TcpSink.cs
+++ b/src/Serilog.Sinks.Splunk/Sinks/Splunk/TcpSink.cs
@@ -102,7 +102,7 @@ namespace Serilog.Sinks.Splunk
 
         private static SplunkJsonFormatter CreateDefaultFormatter(IFormatProvider formatProvider, bool renderTemplate)
         {
-            return new SplunkJsonFormatter(renderMessage: true, formatProvider: formatProvider, renderTemplate: renderTemplate);
+            return new SplunkJsonFormatter(renderTemplate, formatProvider);
         }
 
         /// <inheritdoc/>

--- a/src/Serilog.Sinks.Splunk/Sinks/Splunk/UdpSink.cs
+++ b/src/Serilog.Sinks.Splunk/Sinks/Splunk/UdpSink.cs
@@ -96,7 +96,7 @@ namespace Serilog.Sinks.Splunk
 
         private static SplunkJsonFormatter CreateDefaultFormatter(IFormatProvider formatProvider, bool renderTemplate)
         {
-            return new SplunkJsonFormatter(renderMessage: true, formatProvider: formatProvider, renderTemplate: renderTemplate);
+            return new SplunkJsonFormatter(renderTemplate, formatProvider);
         }
 
         /// <inheritdoc/>

--- a/src/Serilog.Sinks.Splunk/project.json
+++ b/src/Serilog.Sinks.Splunk/project.json
@@ -1,5 +1,5 @@
 ﻿{
-  "version": "2.0.1",
+  "version": "2.1.0-*",
   "description": "The Splunk Sink for Serilog",
   "authors": [
     "Matthew Erbs, Serilog Contributors"

--- a/test/Serilog.Sinks.Splunk.Tests/Properties/launchSettings.json
+++ b/test/Serilog.Sinks.Splunk.Tests/Properties/launchSettings.json
@@ -1,0 +1,11 @@
+{
+  "profiles": {
+    "test": {
+      "commandName": "test"
+    },
+    "test-dnxcore50": {
+      "commandName": "test",
+      "sdkVersion": "dnx-coreclr-win-x86.1.0.0-rc1-final"
+    }
+  }
+}

--- a/test/Serilog.Sinks.Splunk.Tests/Serilog.Sinks.Splunk.Tests.xproj
+++ b/test/Serilog.Sinks.Splunk.Tests/Serilog.Sinks.Splunk.Tests.xproj
@@ -1,0 +1,18 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>3c2d8e01-5580-426a-bdd9-ec59cd98e618</ProjectGuid>
+    <RootNamespace>Serilog.Sinks.Splunk.Tests</RootNamespace>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">.\obj</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
+  </PropertyGroup>
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.targets" Condition="'$(VSToolsPath)' != ''" />
+</Project>

--- a/test/Serilog.Sinks.Splunk.Tests/SplunkJsonFormatterTests.cs
+++ b/test/Serilog.Sinks.Splunk.Tests/SplunkJsonFormatterTests.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.IO;
+using Newtonsoft.Json.Linq;
+using Xunit;
+using Serilog.Sinks.Splunk.Tests.Support;
+
+namespace Serilog.Sinks.Splunk.Tests
+{
+    public class SplunkJsonFormatterTests
+    {
+        void AssertValidJson(Action<ILogger> act)
+        {
+            var output = new StringWriter();
+            var formatter = new SplunkJsonFormatter();
+            var log = new LoggerConfiguration()
+                .WriteTo.Sink(new TextWriterSink(output, formatter))
+                .CreateLogger();
+
+            act(log);
+
+            var json = output.ToString();
+
+            // Unfortunately this will not detect all JSON formatting issues; better than nothing however.
+            JObject.Parse(json);
+        }
+
+        [Fact]
+        public void AnEmptyEventIsValidJson()
+        {
+            AssertValidJson(log => log.Information("No properties"));
+        }
+
+        [Fact]
+        public void AMinimalEventIsValidJson()
+        {
+            AssertValidJson(log => log.Information("One {Property}", 42));
+        }
+
+        [Fact]
+        public void MultiplePropertiesAreDelimited()
+        {
+            AssertValidJson(log => log.Information("Property {First} and {Second}", "One", "Two"));
+        }
+
+        [Fact]
+        public void ExceptionsAreFormattedToValidJson()
+        {
+            AssertValidJson(log => log.Information(new DivideByZeroException(), "With exception"));
+        }
+
+        [Fact]
+        public void ExceptionAndPropertiesAreValidJson()
+        {
+            AssertValidJson(log => log.Information(new DivideByZeroException(), "With exception and {Property}", 42));
+        }
+    }
+}

--- a/test/Serilog.Sinks.Splunk.Tests/SplunkJsonFormatterTests.cs
+++ b/test/Serilog.Sinks.Splunk.Tests/SplunkJsonFormatterTests.cs
@@ -10,18 +10,17 @@ namespace Serilog.Sinks.Splunk.Tests
     {
         void AssertValidJson(Action<ILogger> act)
         {
-            var output = new StringWriter();
-            var formatter = new SplunkJsonFormatter(false, null);
+            StringWriter outputRendered = new StringWriter(), output = new StringWriter();
             var log = new LoggerConfiguration()
-                .WriteTo.Sink(new TextWriterSink(output, formatter))
+                .WriteTo.Sink(new TextWriterSink(output, new SplunkJsonFormatter(false, null)))
+                .WriteTo.Sink(new TextWriterSink(outputRendered, new SplunkJsonFormatter(true, null)))
                 .CreateLogger();
 
             act(log);
 
-            var json = output.ToString();
-
             // Unfortunately this will not detect all JSON formatting issues; better than nothing however.
-            JObject.Parse(json);
+            JObject.Parse(output.ToString());
+            JObject.Parse(outputRendered.ToString());
         }
 
         [Fact]

--- a/test/Serilog.Sinks.Splunk.Tests/SplunkJsonFormatterTests.cs
+++ b/test/Serilog.Sinks.Splunk.Tests/SplunkJsonFormatterTests.cs
@@ -11,7 +11,7 @@ namespace Serilog.Sinks.Splunk.Tests
         void AssertValidJson(Action<ILogger> act)
         {
             var output = new StringWriter();
-            var formatter = new SplunkJsonFormatter();
+            var formatter = new SplunkJsonFormatter(false, null);
             var log = new LoggerConfiguration()
                 .WriteTo.Sink(new TextWriterSink(output, formatter))
                 .CreateLogger();

--- a/test/Serilog.Sinks.Splunk.Tests/Support/TextWriterSink.cs
+++ b/test/Serilog.Sinks.Splunk.Tests/Support/TextWriterSink.cs
@@ -1,0 +1,24 @@
+﻿using System.IO;
+using Serilog.Core;
+using Serilog.Events;
+using Serilog.Formatting;
+
+namespace Serilog.Sinks.Splunk.Tests.Support
+{
+    public class TextWriterSink : ILogEventSink
+    {
+        readonly StringWriter _output;
+        readonly ITextFormatter _formatter;
+
+        public TextWriterSink(StringWriter output, ITextFormatter formatter)
+        {
+            _output = output;
+            _formatter = formatter;
+        }
+
+        public void Emit(LogEvent logEvent)
+        {
+            _formatter.Format(logEvent, _output);
+        }
+    }
+}

--- a/test/Serilog.Sinks.Splunk.Tests/project.json
+++ b/test/Serilog.Sinks.Splunk.Tests/project.json
@@ -1,0 +1,24 @@
+{
+  "testRunner": "xunit",
+  "dependencies": {
+    "Serilog.Sinks.Splunk": { "target": "project" },
+    "xunit": "2.1.0",
+    "dotnet-test-xunit": "1.0.0-rc2-build10025",
+    "Newtonsoft.Json": "8.0.3"
+  },
+  "frameworks": {
+    "net4.5.2": { },
+    "netcoreapp1.0": {
+      "dependencies": {
+        "Microsoft.NETCore.App": {
+          "type": "platform",
+          "version": "1.0.0"
+        }
+      },
+      "imports": [
+        "dnxcore50",
+        "portable-net45+win8"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Breaks the dependency on Serilog's `JsonFormatter` virtual extension points for: https://github.com/serilog/serilog/pull/819

Adds a basic test project and updates to the latest build scripts. Tests are a bit light but at least from this point we can start accumulating them. **Un-tested with Splunk** but based heavily the current production version of the equivalent [Seq JSON frmatter](https://github.com/serilog/serilog-sinks-seq/blob/dev/src/Serilog.Sinks.Seq/Sinks/Seq/RawJsonFormatter.cs), which has been free of any regressions after moving to the same model.

I took the opportunity to scrap several constructor parameters on `SplunkJsonFormatter` that are unlikely to be used, but were previously accepted by the base class (`omitEnclosingObject`, `closingDelimiter`).

I also removed rendering of the `Renderings` JSON property, which while it was emitted by the early version of the sink, is very unlikely to be used in Splunk and incurs a substantial size overhead per event if format specifiers are used in message templates.

This may be a breaking change for some consumers, if they were constructing `SplunkFormatter` manually, but I'm not sure how often that API is used.

On any/all of the above points we could revert to the old behavior, just thought I'd put this particular set of options out there. Let me know your thoughts.

Cheers!