### PR TITLE
Make it possible to override the text formatter implementation

### DIFF
--- a/src/Serilog.Sinks.Splunk/SplunkLoggingConfigurationExtensions.cs
+++ b/src/Serilog.Sinks.Splunk/SplunkLoggingConfigurationExtensions.cs
@@ -17,6 +17,7 @@ using System;
 using System.Net.Http;
 using Serilog.Configuration;
 using Serilog.Events;
+using Serilog.Formatting;
 using Serilog.Sinks.Splunk;
 
 namespace Serilog
@@ -85,6 +86,48 @@ namespace Serilog
                 batchSizeLimit,
                 formatProvider,
                 renderTemplate,
+                messageHandler);
+
+            return configuration.Sink(eventCollectorSink, restrictedToMinimumLevel);
+        }
+
+        /// <summary>
+        ///     Adds a sink that writes log events as to a Splunk instance via the HTTP Event Collector.
+        /// </summary>
+        /// <param name="configuration">The logger config</param>
+        /// <param name="splunkHost">The Splunk host that is configured with an Event Collector</param>
+        /// <param name="eventCollectorToken">The token provided to authenticate to the Splunk Event Collector</param>
+        /// <param name="jsonFormatter">The text formatter used to render log events into a JSON format for consumption by Splunk</param>
+        /// <param name="uriPath">Change the default endpoint of the Event Collector e.g. services/collector/event</param>
+        /// <param name="restrictedToMinimumLevel">The minimum log event level required in order to write an event to the sink.</param>
+        /// <param name="outputTemplate">The output template to be used when logging</param>
+        /// <param name="batchIntervalInSeconds">The interval in seconds that the queue should be instpected for batching</param>
+        /// <param name="batchSizeLimit">The size of the batch</param>
+        /// <param name="messageHandler">The handler used to send HTTP requests</param>
+        /// <returns></returns>
+        public static LoggerConfiguration EventCollector(
+            this LoggerSinkConfiguration configuration,
+            string splunkHost,
+            string eventCollectorToken,
+            ITextFormatter jsonFormatter,
+            string uriPath = "services/collector",
+            LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
+            string outputTemplate = DefaultOutputTemplate,
+            int batchIntervalInSeconds = 2,
+            int batchSizeLimit = 100,
+            HttpMessageHandler messageHandler = null)
+        {
+            if (configuration == null) throw new ArgumentNullException(nameof(configuration));
+            if (jsonFormatter == null) throw new ArgumentNullException(nameof(jsonFormatter));
+            if (outputTemplate == null) throw new ArgumentNullException(nameof(outputTemplate));
+
+            var eventCollectorSink = new EventCollectorSink(
+                splunkHost,
+                eventCollectorToken,
+                uriPath,
+                batchIntervalInSeconds,
+                batchSizeLimit,
+                jsonFormatter,
                 messageHandler);
 
             return configuration.Sink(eventCollectorSink, restrictedToMinimumLevel);


### PR DESCRIPTION
I needed to replace the SplunkJsonFormatter with my own implementation, this new constructor makes it easy to do so. Would be happy if this could make to the Nuget package! :)