### PR TITLE
Fix deadlock when calling Dispose from the UI thread.

### DIFF
--- a/src/Serilog.Sinks.Splunk/Sinks/Splunk/EventCollectorSink.cs
+++ b/src/Serilog.Sinks.Splunk/Sinks/Splunk/EventCollectorSink.cs
@@ -205,7 +205,7 @@ namespace Serilog.Sinks.Splunk
             }
 
             var request = new EventCollectorRequest(_splunkHost, allEvents.ToString(), _uriPath);
-            var response = await _httpClient.SendAsync(request);
+            var response = await _httpClient.SendAsync(request).ConfigureAwait(false);
 
             if (response.IsSuccessStatusCode)
             {


### PR DESCRIPTION
Basically, if you call Dsipose from the UI thread, or any other thread that has a synchronization context, it blocks and waits for the Send to complete. But then _httpClient.SendAsync tries to complete in the original context, but it can't because it's already blocked. Since there's no timeout, it gets deadlocked forever.

Adding the ConfigureAwait(false) causes the _httpClient request to be completed in the thread pool instead, avoiding the deadlock.