### PR TITLE
Build Issues with 2.4.0

### DIFF
--- a/Build.ps1
+++ b/Build.ps1
@@ -25,7 +25,11 @@ foreach ($src in ls src/*) {
 	echo "build: Packaging project in $src"
 
     & dotnet build -c Release --version-suffix=$buildSuffix
-    & dotnet pack -c Release --include-symbols -o ..\..\artifacts --version-suffix=$suffix --no-build
+    if ($suffix) {
+        & dotnet pack -c Release --include-symbols -o ..\..\artifacts --version-suffix=$suffix --no-build
+    } else {
+        & dotnet pack -c Release --include-symbols -o ..\..\artifacts --no-build
+    }
     if($LASTEXITCODE -ne 0) { exit 1 }    
 
     Pop-Location

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+## 2.4.0
+- [#62] Default fields added by serilog to splunk
+- [#63] Possible thread leak when ILogger instances are disposed
+
 ## 2.3.0
 - [#59] Added ability to use custom fields with HEC.  See http://dev.splunk.com/view/event-collector/SP-CAAAFB6.
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,24 +1,24 @@
 ## 2.4.0
-- [#62] Default fields added by serilog to splunk
-- [#63] Possible thread leak when ILogger instances are disposed
+- #62 Default fields added by serilog to splunk
+- #63 Possible thread leak when ILogger instances are disposed
 
 ## 2.3.0
-- [#59] Added ability to use custom fields with HEC.  See http://dev.splunk.com/view/event-collector/SP-CAAAFB6.
+- 59 Added ability to use custom fields with HEC.  See http://dev.splunk.com/view/event-collector/SP-CAAAFB6.
 
 ## 2.2.1
-- [#47] Tooling updates to VS2017
-- [#48] 
-- [#49]
-- [#52] 
+- #47 Tooling updates to VS2017
+- #48
+- #49
+- #52
 
 ## 2.1.3
-- [#45] - Deadlock fix on UI thread.
+- #45 - Deadlock fix on UI thread.
 
 ## 2.1.2
-- [#43](https://github.com/serilog/serilog-sinks-splunk/pull/43) - Extend sink & static configuration to allow for custom JSON formatter.
+- #43 - Extend sink & static configuration to allow for custom JSON formatter.
 
 ## 2.1.1
-- [#38](https://github.com/serilog/serilog-sinks-splunk/issues/38) - Fix for HttpEventlogCollector and sourceType
+- #38(https://github.com/serilog/serilog-sinks-splunk/issues/38) - Fix for HttpEventlogCollector and sourceType
 - Clean up of sample app using examples of host, sourcetype, source override
 
 ## 2.1.0

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,31 +1,31 @@
 ## 2.4.0
-- #62 Default fields added by serilog to splunk
-- #63 Possible thread leak when ILogger instances are disposed
+- [#62](https://github.com/serilog/serilog-sinks-splunk/issues/62) Default fields added by serilog to splunk
+- [#63](https://github.com/serilog/serilog-sinks-splunk/issues/63) Possible thread leak when ILogger instances are disposed
 
 ## 2.3.0
-- 59 Added ability to use custom fields with HEC.  See http://dev.splunk.com/view/event-collector/SP-CAAAFB6.
+- [#59](https://github.com/serilog/serilog-sinks-splunk/issues/59) Added ability to use custom fields with HEC.  See http://dev.splunk.com/view/event-collector/SP-CAAAFB6.
 
 ## 2.2.1
-- #47 Tooling updates to VS2017
-- #48
-- #49
-- #52
+- [#47](https://github.com/serilog/serilog-sinks-splunk/issues/47) Tooling updates to VS2017
+- [#48](https://github.com/serilog/serilog-sinks-splunk/issues/48)
+- [#49](https://github.com/serilog/serilog-sinks-splunk/issues/49)
+- [#52](https://github.com/serilog/serilog-sinks-splunk/issues/52)
 
 ## 2.1.3
-- #45 - Deadlock fix on UI thread.
+- [#45](https://github.com/serilog/serilog-sinks-splunk/issues/45) - Deadlock fix on UI thread.
 
 ## 2.1.2
-- #43 - Extend sink & static configuration to allow for custom JSON formatter.
+- [#43](https://github.com/serilog/serilog-sinks-splunk/issues/43) - Extend sink & static configuration to allow for custom JSON formatter.
 
 ## 2.1.1
-- #38(https://github.com/serilog/serilog-sinks-splunk/issues/38) - Fix for HttpEventlogCollector and sourceType
+- [#38](https://github.com/serilog/serilog-sinks-splunk/issues/38) - Fix for HttpEventlogCollector and sourceType
 - Clean up of sample app using examples of host, sourcetype, source override
 
 ## 2.1.0
 
 * Change to use a standalone formatter
-* Resolves #32 & #26 by exposing `HttpMessageHandler`
-* Resolves #30 by ignoring OSX build and including tests in `build.sh` for TravisCI
+* Resolves - [#32](https://github.com/serilog/serilog-sinks-splunk/issues/32) & - [#26](https://github.com/serilog/serilog-sinks-splunk/issues/26) by exposing `HttpMessageHandler`
+* Resolves - [#30](https://github.com/serilog/serilog-sinks-splunk/issues/30) by ignoring OSX build and including tests in `build.sh` for TravisCI
 
 ## 2.0
  - Support for DotNet Core

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,5 @@
 ## 2.4.0
-- [#62](https://github.com/serilog/serilog-sinks-splunk/issues/62) Default fields added by serilog to splunk
+- [#62](https://github.com/serilog/serilog-sinks-splunk/issues/62) Default fields added by Serilog to splunk
 - [#63](https://github.com/serilog/serilog-sinks-splunk/issues/63) Possible thread leak when ILogger instances are disposed
 
 ## 2.3.0

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ More information is available on the [wiki](https://github.com/serilog/serilog-s
 
 Branch  | AppVeyor | Travis
 ------------- | ------------- |-------------
-master |  [![Build status](https://ci.appveyor.com/api/projects/status/yt40wg34t8oj61al/branch/master?svg=true)](https://ci.appveyor.com/project/serilog/serilog-sinks-splunk/branch/dev) | ![](https://travis-ci.org/serilog/serilog-sinks-splunk.svg?branch=master) 
-dev | [![Build status](https://ci.appveyor.com/api/projects/status/yt40wg34t8oj61al/branch/dev?svg=true)](https://ci.appveyor.com/project/serilog/serilog-sinks-splunk/branch/master) | ![](https://travis-ci.org/serilog/serilog-sinks-splunk.svg?branch=dev)
+master |  [![Build status](https://ci.appveyor.com/api/projects/status/yt40wg34t8oj61al/branch/master?svg=true)](https://ci.appveyor.com/project/serilog/serilog-sinks-splunk/branch/master) | ![](https://travis-ci.org/serilog/serilog-sinks-splunk.svg?branch=master) 
+dev | [![Build status](https://ci.appveyor.com/api/projects/status/yt40wg34t8oj61al/branch/dev?svg=true)](https://ci.appveyor.com/project/serilog/serilog-sinks-splunk/branch/dev) | ![](https://travis-ci.org/serilog/serilog-sinks-splunk.svg?branch=dev)
 
 _Serilog is copyright &copy; 2013-2016 Serilog Contributors - Provided under the [Apache License, Version 2.0](http://apache.org/licenses/LICENSE-2.0.html). Needle and thread logo a derivative of work by [Kenneth Appiah](http://www.kensets.com/)._

--- a/src/Serilog.Sinks.Splunk/Serilog.Sinks.Splunk.csproj
+++ b/src/Serilog.Sinks.Splunk/Serilog.Sinks.Splunk.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>The Splunk Sink for Serilog</Description>
-    <VersionPrefix>2.3.1</VersionPrefix>
+    <VersionPrefix>2.4.0</VersionPrefix>
     <Authors>Matthew Erbs, Serilog Contributors</Authors>
     <TargetFrameworks>net45;netstandard1.1;netstandard1.3</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>


### PR DESCRIPTION
2.4.0 release with build fixes for DotNet Core 2.0 tooling.