### PR TITLE
Updated NuGet API Key.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,7 +10,7 @@ artifacts:
 deploy:
 - provider: NuGet
   api_key:
-    secure: nvZ/z+pMS91b3kG4DgfES5AcmwwGoBYQxr9kp4XiJHj25SAlgdIxFx++1N0lFH2x
+    secure: bd9z4P73oltOXudAjPehwp9iDKsPtC+HbgshOrSgoyQKr5xVK+bxJQngrDJkHdY8
   skip_symbols: true
   on:
     branch: /^(master|dev)$/


### PR DESCRIPTION
Post moving to NuGet orgs (see [here](https://github.com/serilog/serilog/issues/1159)) a new key is needed to push packages

This is created under the org in NuGet.