### PR TITLE
Adding target frameworks for net45 & netstandard2.0, removing netstandard1.3

### DIFF
--- a/src/Serilog.Sinks.Splunk/Serilog.Sinks.Splunk.csproj
+++ b/src/Serilog.Sinks.Splunk/Serilog.Sinks.Splunk.csproj
@@ -4,7 +4,7 @@
     <Description>The Splunk Sink for Serilog</Description>
     <VersionPrefix>3.0.0</VersionPrefix>
     <Authors>Matthew Erbs, Serilog Contributors</Authors>
-    <TargetFrameworks>netstandard1.1;netstandard1.3</TargetFrameworks>
+    <TargetFrameworks>net45;netstandard1.1;netstandard2.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>Serilog.Sinks.Splunk</AssemblyName>
     <PackageId>Serilog.Sinks.Splunk</PackageId>
@@ -21,12 +21,28 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
-    <PackageReference Include="Serilog" Version="2.6.0" />
-    <PackageReference Include="System.Net.Http" Version="4.3.3" />
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'net45' ">
+    <!-- Don't reference unused System assemblies -->
+    <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.1' ">
+    <!-- Don't reference the full NETStandard.Library -->
+    <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
+  </PropertyGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Net.Http" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.1' ">
+    <PackageReference Include="System.Net.Http" Version="4.3.0" />
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Serilog" Version="2.6.0" />
     <PackageReference Include="Serilog.Sinks.PeriodicBatching" Version="2.1.1" />
   </ItemGroup>
 


### PR DESCRIPTION
Related to issue #104.  Trying to align target frameworks closer to how core Serilog library works.  Here is what I think should be done.  Let me know your thoughts.

1. Removing targetframework for netstandard1.3 because it's just a superset of netstandard1.1
2. Removing the need to target the full NETStandard.Library when targeting netstandard1.1 (NETStandard.Library ends up a dependency in the nupkg when targeting pre-netstandard2.0)
3. Adding targetframework for net45 to use framework assembly for System.Net.Http when targeting full .NET Framework
4. Adding targetframework for netstandard2.0 to remove need to reference System.Net.Http package