### PR TITLE
Removing GenerateAssemblyVersionAttribute from Serilog.Sinks.Splunk.csproj

### DIFF
--- a/src/Serilog.Sinks.Splunk/Serilog.Sinks.Splunk.csproj
+++ b/src/Serilog.Sinks.Splunk/Serilog.Sinks.Splunk.csproj
@@ -14,7 +14,6 @@
     <PackageLicenseUrl>http://www.apache.org/licenses/LICENSE-2.0</PackageLicenseUrl>
     <RepositoryUrl>https://github.com/serilog/serilog-sinks-splunk</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
-    <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
     <AssemblyOriginatorKeyFile>../../assets/Serilog.snk</AssemblyOriginatorKeyFile>
     <PublicSign>true</PublicSign>
     <SignAssembly>true</SignAssembly>


### PR DESCRIPTION
Addresses issue #76.  Adds AssemblyVersion Attribute/Number back to Serilog.Sinks.Splunk.dll.