### PR TITLE
Adding Condition=" '$(OS)' != 'Windows_NT' " to PublicSign attribute

### DIFF
--- a/src/Serilog.Sinks.Splunk/Serilog.Sinks.Splunk.csproj
+++ b/src/Serilog.Sinks.Splunk/Serilog.Sinks.Splunk.csproj
@@ -15,7 +15,7 @@
     <RepositoryUrl>https://github.com/serilog/serilog-sinks-splunk</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <AssemblyOriginatorKeyFile>../../assets/Serilog.snk</AssemblyOriginatorKeyFile>
-    <PublicSign>true</PublicSign>
+    <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
     <SignAssembly>true</SignAssembly>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>


### PR DESCRIPTION
Adding Condition=" '$(OS)' != 'Windows_NT' " to PublicSign attribute in Serilog.Sinks.Splunk.csproj to solve issue #76.  When the PublicSign attribute is removed, the assembly is fully and properly signed. 
 Conditionally applying this attribute based on OS aligns with what the Serilog core library and other sinks are doing.