### PR TITLE
Version bump & extend signing to TCP & UDP sinks

### DIFF
--- a/src/Serilog.Sinks.Splunk/Serilog.Sinks.Splunk.csproj
+++ b/src/Serilog.Sinks.Splunk/Serilog.Sinks.Splunk.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>The Splunk Sink for Serilog</Description>
-    <VersionPrefix>3.2.0</VersionPrefix>
+    <VersionPrefix>3.3.0</VersionPrefix>
     <Authors>Matthew Erbs, Serilog Contributors</Authors>
     <TargetFrameworks>net45;netstandard1.1;netstandard2.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/Serilog.Sinks.TCP/Properties/AssemblyInfo.cs
+++ b/src/Serilog.Sinks.TCP/Properties/AssemblyInfo.cs
@@ -1,6 +1,9 @@
 ﻿using System.Reflection;
 using System.Runtime.CompilerServices;
 
-[assembly: AssemblyVersion("2.0.0.0")]
-
-[assembly: InternalsVisibleTo("Serilog.Sinks.Splunk.Tests")]
+[assembly: InternalsVisibleTo("Serilog.Sinks.Splunk.Tests, PublicKey=" +
+                              "0024000004800000940000000602000000240000525341310004000001000100fb8d13fd344a1c" +
+                              "6fe0fe83ef33c1080bf30690765bc6eb0df26ebfdf8f21670c64265b30db09f73a0dea5b3db4c9" +
+                              "d18dbf6d5a25af5ce9016f281014d79dc3b4201ac646c451830fc7e61a2dfd633d34c39f87b818" +
+                              "94191652df5ac63cc40c77f3542f702bda692e6e8a9158353df189007a49da0f3cfd55eb250066" +
+                              "b19485ec")]

--- a/src/Serilog.Sinks.TCP/Serilog.Sinks.Splunk.TCP.csproj
+++ b/src/Serilog.Sinks.TCP/Serilog.Sinks.Splunk.TCP.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>The Splunk TCP Sink for Serilog</Description>
-    <VersionPrefix>1.1.0</VersionPrefix>
+    <VersionPrefix>1.2.0</VersionPrefix>
     <Authors>Matthew Erbs, Serilog Contributors</Authors>
     <TargetFrameworks>net45;</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -15,6 +15,9 @@
     <RepositoryUrl>https://github.com/serilog/serilog-sinks-splunk</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
+    <AssemblyOriginatorKeyFile>../../assets/Serilog.snk</AssemblyOriginatorKeyFile>
+    <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
+    <SignAssembly>true</SignAssembly>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Serilog.Sinks.UDP/Properties/AssemblyInfo.cs
+++ b/src/Serilog.Sinks.UDP/Properties/AssemblyInfo.cs
@@ -1,6 +1,9 @@
 ﻿using System.Reflection;
 using System.Runtime.CompilerServices;
 
-[assembly: AssemblyVersion("2.0.0.0")]
-
-[assembly: InternalsVisibleTo("Serilog.Sinks.Splunk.Tests")]
+[assembly: InternalsVisibleTo("Serilog.Sinks.Splunk.Tests, PublicKey=" +
+                              "0024000004800000940000000602000000240000525341310004000001000100fb8d13fd344a1c" +
+                              "6fe0fe83ef33c1080bf30690765bc6eb0df26ebfdf8f21670c64265b30db09f73a0dea5b3db4c9" +
+                              "d18dbf6d5a25af5ce9016f281014d79dc3b4201ac646c451830fc7e61a2dfd633d34c39f87b818" +
+                              "94191652df5ac63cc40c77f3542f702bda692e6e8a9158353df189007a49da0f3cfd55eb250066" +
+                              "b19485ec")]

--- a/src/Serilog.Sinks.UDP/Serilog.Sinks.Splunk.UDP.csproj
+++ b/src/Serilog.Sinks.UDP/Serilog.Sinks.Splunk.UDP.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>The Splunk UDP Sink for Serilog</Description>
-    <VersionPrefix>1.1.0</VersionPrefix>
+    <VersionPrefix>1.2.0</VersionPrefix>
     <Authors>Matthew Erbs, Serilog Contributors</Authors>
     <TargetFrameworks>net45</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -15,6 +15,9 @@
     <RepositoryUrl>https://github.com/serilog/serilog-sinks-splunk</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
+    <AssemblyOriginatorKeyFile>../../assets/Serilog.snk</AssemblyOriginatorKeyFile>
+    <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
+    <SignAssembly>true</SignAssembly>
   </PropertyGroup>
  
   <ItemGroup>


### PR DESCRIPTION
* Version of sink to `3.3`
* Version of TCP & UDP to `1.2`
* Signing of TCP & UDP sinks