### PR TITLE
X-Splunk-Request-Channel header added

### DIFF
--- a/src/Serilog.Sinks.Splunk/Sinks/Splunk/EventCollectorClient.cs
+++ b/src/Serilog.Sinks.Splunk/Sinks/Splunk/EventCollectorClient.cs
@@ -21,14 +21,26 @@ namespace Serilog.Sinks.Splunk
 {
     internal class EventCollectorClient : HttpClient, IDisposable
     {
+        private const string AUTH_SCHEME = "Splunk";
+        private const string SPLUNK_REQUEST_CHANNEL = "X-Splunk-Request-Channel";
+
         public EventCollectorClient(string eventCollectorToken) : base()
         {
-            DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Splunk", eventCollectorToken);
+            SetHeaders(eventCollectorToken);
         }
 
         public EventCollectorClient(string eventCollectorToken, HttpMessageHandler messageHandler) : base(messageHandler)
         {
-            DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Splunk", eventCollectorToken);
+            SetHeaders(eventCollectorToken);
+        }
+
+        private void SetHeaders(string eventCollectorToken)
+        {
+            DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(AUTH_SCHEME, eventCollectorToken);
+            if (!this.DefaultRequestHeaders.Contains(SPLUNK_REQUEST_CHANNEL))
+            {
+                this.DefaultRequestHeaders.Add(SPLUNK_REQUEST_CHANNEL, Guid.NewGuid().ToString());
+            }
         }
     }
 }


### PR DESCRIPTION
When indexer acknowledgment is used this sink is not working.

Error displayed is "Data channel is missing."
Behavior is explained here: https://docs.splunk.com/Documentation/Splunk/8.0.4/Data/AboutHECIDXAck

It is a small change in  EventCollectorClient class (header called X-Splunk-Request-Channel is added). 