### PR TITLE
BoundedConcurrentQueue does not accept a negative queue limit. Using …

### DIFF
--- a/src/Serilog.Sinks.Splunk/Sinks/Splunk/EventCollectorSink.cs
+++ b/src/Serilog.Sinks.Splunk/Sinks/Splunk/EventCollectorSink.cs
@@ -31,7 +31,7 @@ namespace Serilog.Sinks.Splunk
     /// </summary>
     public class EventCollectorSink : PeriodicBatchingSink
     {
-        private const int NoQueueLimit = -1;
+        private const int DefaultQueueLimit = 100000;
 
         private readonly string _splunkHost;
         private readonly string _uriPath;
@@ -186,7 +186,7 @@ namespace Serilog.Sinks.Splunk
             int? queueLimit,
             ITextFormatter jsonFormatter,
             HttpMessageHandler messageHandler = null)
-            : base(batchSizeLimit, TimeSpan.FromSeconds(batchIntervalInSeconds), queueLimit ?? NoQueueLimit)
+            : base(batchSizeLimit, TimeSpan.FromSeconds(batchIntervalInSeconds), queueLimit ?? DefaultQueueLimit)
         {
             _uriPath = uriPath;
             _splunkHost = splunkHost;


### PR DESCRIPTION
I made a mistake, BoundedConcurrentQueue does not accept a negative queue limit. We need to use the default specified in `PeriodicBatchingSinkOptions.QueueLimit`

[PeriodicBatchingSinkOptions.cs#L45](https://github.com/serilog/serilog-sinks-periodicbatching/blob/dev/src/Serilog.Sinks.PeriodicBatching/Sinks/PeriodicBatching/PeriodicBatchingSinkOptions.cs#L45)