### PR TITLE
Bugfix/udp tcp sink fixes #155

### DIFF
--- a/serilog-sinks-splunk.sln
+++ b/serilog-sinks-splunk.sln
@@ -43,6 +43,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".github", ".github", "{A9F9
 		.github\workflows\ci.yml = .github\workflows\ci.yml
 	EndProjectSection
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Serilog.Sinks.Splunk.TCP.Tests", "test\Serilog.Sinks.Splunk.TCP.Tests\Serilog.Sinks.Splunk.TCP.Tests.csproj", "{9F0EA87D-1D36-47C0-887E-29A1F7DB6979}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -73,6 +75,10 @@ Global
 		{1B9DEFA3-D600-45FA-93A5-79006076FB5C}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{1B9DEFA3-D600-45FA-93A5-79006076FB5C}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{1B9DEFA3-D600-45FA-93A5-79006076FB5C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9F0EA87D-1D36-47C0-887E-29A1F7DB6979}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9F0EA87D-1D36-47C0-887E-29A1F7DB6979}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9F0EA87D-1D36-47C0-887E-29A1F7DB6979}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9F0EA87D-1D36-47C0-887E-29A1F7DB6979}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -84,6 +90,7 @@ Global
 		{F74FCFD0-536B-4311-AA66-0BD16112D895} = {7A774CBB-A6E9-4854-B4DB-4CF860B0C1C5}
 		{FE1504A6-5444-4B87-819C-E6F477662B7F} = {7A774CBB-A6E9-4854-B4DB-4CF860B0C1C5}
 		{21EEF50A-C0FC-4406-97A1-8F5F499AE2FC} = {1C75E4A9-4CB1-497C-AD17-B438882051A1}
+		{9F0EA87D-1D36-47C0-887E-29A1F7DB6979} = {B9451AD8-09B9-4C09-A152-FBAE24806614}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {D7BFF439-D18D-4124-A36F-15CFB8E84BCC}

--- a/src/Serilog.Sinks.Splunk/Serilog.Sinks.Splunk.csproj
+++ b/src/Serilog.Sinks.Splunk/Serilog.Sinks.Splunk.csproj
@@ -10,7 +10,7 @@
     <PackageId>Serilog.Sinks.Splunk</PackageId>
     <PackageTags>serilog;splunk;logging;event;collector;hec</PackageTags>
     <AssemblyOriginatorKeyFile>../../assets/Serilog.snk</AssemblyOriginatorKeyFile>
-    <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
+    <PublicSign Condition=" '$(Configuration)' == 'Debug' ">true</PublicSign>
     <SignAssembly>true</SignAssembly>
     <RootNamespace>Serilog</RootNamespace>
     <IsPackable>true</IsPackable>

--- a/src/Serilog.Sinks.TCP/Serilog.Sinks.Splunk.TCP.csproj
+++ b/src/Serilog.Sinks.TCP/Serilog.Sinks.Splunk.TCP.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <Import Project="../common.props"/>
-  
+
   <PropertyGroup>
     <Description>The Splunk TCP Sink for Serilog</Description>
     <TargetFrameworks>netstandard2.1;netstandard2.0</TargetFrameworks>
@@ -10,12 +10,15 @@
     <PackageTags>serilog;splunk;logging;tcp</PackageTags>
     <AssemblyOriginatorKeyFile>../../assets/Serilog.snk</AssemblyOriginatorKeyFile>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
-    <SignAssembly>true</SignAssembly>
+    <SignAssembly>False</SignAssembly>
     <IsPackable>true</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Serilog.Sinks.Splunk" Version="4.0.0" />
     <PackageReference Include="Splunk.Logging.Common.Core" Version="1.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Serilog.Sinks.Splunk\Serilog.Sinks.Splunk.csproj" />
   </ItemGroup>
 </Project>

--- a/src/Serilog.Sinks.TCP/Serilog.Sinks.Splunk.TCP.csproj
+++ b/src/Serilog.Sinks.TCP/Serilog.Sinks.Splunk.TCP.csproj
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <Description>The Splunk TCP Sink for Serilog</Description>
-    <TargetFrameworks>netstandard2.1;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;netstandard2.0;net6.0;net8.0</TargetFrameworks>
     <AssemblyName>Serilog.Sinks.Splunk.TCP</AssemblyName>
     <PackageId>Serilog.Sinks.Splunk.TCP</PackageId>
     <PackageTags>serilog;splunk;logging;tcp</PackageTags>

--- a/src/Serilog.Sinks.TCP/Serilog.Sinks.Splunk.TCP.csproj
+++ b/src/Serilog.Sinks.TCP/Serilog.Sinks.Splunk.TCP.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <Import Project="../common.props"/>
+  <Import Project="../common.props" />
 
   <PropertyGroup>
     <Description>The Splunk TCP Sink for Serilog</Description>
@@ -9,14 +9,10 @@
     <PackageId>Serilog.Sinks.Splunk.TCP</PackageId>
     <PackageTags>serilog;splunk;logging;tcp</PackageTags>
     <AssemblyOriginatorKeyFile>../../assets/Serilog.snk</AssemblyOriginatorKeyFile>
-    <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
-    <SignAssembly>False</SignAssembly>
+    <PublicSign Condition=" '$(Configuration)' == 'Debug' ">true</PublicSign>
+    <SignAssembly>true</SignAssembly>
     <IsPackable>true</IsPackable>
   </PropertyGroup>
-
-  <ItemGroup>
-    <PackageReference Include="Splunk.Logging.Common.Core" Version="1.0.0" />
-  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\Serilog.Sinks.Splunk\Serilog.Sinks.Splunk.csproj" />

--- a/src/Serilog.Sinks.TCP/Splunk.Logging/ExponentialBackoffTcpReconnectionPolicy.cs
+++ b/src/Serilog.Sinks.TCP/Splunk.Logging/ExponentialBackoffTcpReconnectionPolicy.cs
@@ -1,0 +1,61 @@
+﻿/*
+ * Copyright 2014 Splunk, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"): you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+using System;
+using System.Net;
+using System.Net.Sockets;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Splunk.Logging
+{
+    /// <summary>
+    /// TcpConnectionPolicy implementation that tries to reconnect after
+    /// increasingly long intervals.
+    /// </summary>
+    /// <remarks>
+    /// The intervals double every time, starting from 0s, 1s, 2s, 4s, ...
+    /// until 10 minutes between connections, when it plateaus and does
+    /// not increase the interval length any further.
+    /// </remarks>
+    public class ExponentialBackoffTcpReconnectionPolicy : ITcpReconnectionPolicy
+    {
+        private int ceiling = 10 * 60; // 10 minutes in seconds
+
+        public Socket Connect(Func<IPAddress, int, Socket> connect, IPAddress host, int port, CancellationToken cancellationToken)
+        {
+            int delay = 1; // in seconds
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                try
+                {
+                    return connect(host, port);
+                }
+                catch (SocketException) { }
+
+                // If this is cancelled via the cancellationToken instead of
+                // completing its delay, the next while-loop test will fail,
+                // the loop will terminate, and the method will return null
+                // with no additional connection attempts.
+                Task.Delay(delay * 1000, cancellationToken).Wait();
+                // The nth delay is min(10 minutes, 2^n - 1 seconds).
+                delay = Math.Min((delay + 1) * 2 - 1, ceiling);
+            }
+
+            // cancellationToken has been cancelled.
+            return null;
+        }
+    }
+}

--- a/src/Serilog.Sinks.TCP/Splunk.Logging/FixedSizeQueue.cs
+++ b/src/Serilog.Sinks.TCP/Splunk.Logging/FixedSizeQueue.cs
@@ -1,0 +1,82 @@
+﻿/*
+ * Copyright 2014 Splunk, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"): you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+using System;
+using System.Collections.Concurrent;
+using System.Threading;
+
+namespace Splunk.Logging
+{
+    /// <summary>
+    /// A queue with a maximum size. When the queue is at its maximum size
+    /// and a new item is queued, the oldest item in the queue is dropped.
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    internal class FixedSizeQueue<T>
+    {
+        public int Size { get; private set; }
+        public IProgress<bool> Progress = new Progress<bool>();
+        public bool IsCompleted { get; private set; }
+
+        private readonly BlockingCollection<T> _collection = new BlockingCollection<T>();
+
+        public FixedSizeQueue(int size)
+            : base()
+        {
+            Size = size;
+            IsCompleted = false;
+        }
+
+        public void Enqueue(T obj)
+        {
+            lock (this)
+            {
+                if (IsCompleted)
+                {
+                    throw new InvalidOperationException("Tried to add an item to a completed queue.");
+                }
+
+                _collection.Add(obj);
+
+                while (_collection.Count > Size)
+                {
+                    _collection.Take();
+                }
+                Progress.Report(true);
+            }
+        }
+
+        public void CompleteAdding()
+        {
+            lock (this)
+            {
+                IsCompleted = true;
+            }
+        }
+
+        public T Dequeue(CancellationToken cancellationToken)
+        {
+            return _collection.Take(cancellationToken);
+        }
+
+        public T Dequeue()
+        {
+            return _collection.Take();
+        }
+
+
+        public decimal Count { get { return _collection.Count; } }
+    }
+}

--- a/src/Serilog.Sinks.TCP/Splunk.Logging/ITcpReconnectionPolicy.cs
+++ b/src/Serilog.Sinks.TCP/Splunk.Logging/ITcpReconnectionPolicy.cs
@@ -1,0 +1,66 @@
+﻿/*
+ * Copyright 2014 Splunk, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"): you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+using System;
+using System.Net;
+using System.Net.Sockets;
+using System.Threading;
+
+namespace Splunk.Logging
+{
+    /// <summary>
+    /// TcpConnectionPolicy encapsulates a policy for what logging via TCP should
+    /// do when there is a socket error.
+    /// </summary>
+    /// <remarks>
+    /// TCP loggers in this library (TcpTraceListener and TcpEventSink) take a 
+    /// TcpConnectionPolicy as an argument to their constructor. When the TCP
+    /// session the logger uses has an error, the logger suspends logging and calls
+    /// the Reconnect method of an implementation of TcpConnectionPolicy to get a
+    /// new socket.
+    /// </remarks>
+    public interface ITcpReconnectionPolicy
+    {
+        // A blocking method that should eventually return a Socket when it finally
+        // manages to get a connection, or throw a TcpReconnectFailure if the policy
+        // says to give up trying to connect.
+        /// <summary>
+        /// Try to reestablish a TCP connection.
+        /// </summary>
+        /// <remarks>
+        /// The method should block until it either 
+        /// 
+        /// 1. succeeds and returns a connected TCP socket, or 
+        /// 2. fails and throws a TcpReconnectFailure exception, or
+        /// 3. the cancellationToken is cancelled, in which case the method should
+        ///    return null.
+        ///    
+        /// The method takes a zero-parameter function that encapsulates trying to
+        /// make a single connection and a cancellation token to stop the method
+        /// if the logging system that invoked it is disposed.
+        /// 
+        /// For example, the default ExponentialBackoffTcpConnectionPolicy invokes
+        /// connect after increasingly long intervals until it makes a successful
+        /// connnection, or is cancelled by the cancellationToken, at which point
+        /// it returns null.
+        /// </remarks>
+        /// <param name="connect">A zero-parameter function that tries once to 
+        /// establish a connection.</param>
+        /// <param name="cancellationToken">A token used to cancel the reconnect
+        /// attempt when the invoking logger is disposed.</param>
+        /// <returns>A connected TCP socket.</returns>
+        Socket Connect(Func<IPAddress, int, Socket> connect, IPAddress host, int port, CancellationToken cancellationToken);
+    }
+}

--- a/src/Serilog.Sinks.TCP/Splunk.Logging/LICENSE
+++ b/src/Serilog.Sinks.TCP/Splunk.Logging/LICENSE
@@ -1,0 +1,204 @@
+﻿using static System.Collections.Specialized.BitVector32;
+using System.ComponentModel;
+
+Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a)You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} { name of copyright owner}
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/src/Serilog.Sinks.TCP/Splunk.Logging/README.md
+++ b/src/Serilog.Sinks.TCP/Splunk.Logging/README.md
@@ -1,0 +1,8 @@
+# Splunk.Logging.Common
+
+Original Sources
+https://github.com/splunk/splunk-library-dotnetlogging
+
+These files are included here as the original published library does not contain a strong-name key.
+
+If this ever changes, suggest switching back to the published Nuget package for Splunk.Logging.Common.

--- a/src/Serilog.Sinks.TCP/Splunk.Logging/TcpSocketWriter.cs
+++ b/src/Serilog.Sinks.TCP/Splunk.Logging/TcpSocketWriter.cs
@@ -1,0 +1,201 @@
+﻿/*
+ * Copyright 2014 Splunk, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"): you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+using System;
+using System.Net;
+using System.Net.Sockets;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Splunk.Logging
+{
+    /// <summary>
+    /// TcpSocketWriter encapsulates queueing strings to be written to a TCP socket
+    /// and handling reconnections (according to a TcpConnectionPolicy object passed
+    /// to it) when a TCP session drops.
+    /// </summary>
+    /// <remarks>
+    /// TcpSocketWriter maintains a fixed sized queue of strings to be sent via
+    /// the TCP port and, while the socket is open, sends them as quickly as possible.
+    /// 
+    /// If the TCP session drops, TcpSocketWriter will stop pulling strings off the
+    /// queue until it can reestablish a connection. Any SocketErrors emitted during this
+    /// process will be passed as arguments to invocations of LoggingFailureHandler.
+    /// If the TcpConnectionPolicy.Connect method throws an exception (in particular,
+    /// TcpReconnectFailure to indicate that the policy has reached a point where it 
+    /// will no longer try to establish a connection) then the LoggingFailureHandler 
+    /// event is invoked, and no further attempt to log anything will be made.
+    /// </remarks>
+    public class TcpSocketWriter : IDisposable
+    {
+        private FixedSizeQueue<string> eventQueue;
+        private Thread queueListener;
+        private ITcpReconnectionPolicy reconnectPolicy;
+        private CancellationTokenSource tokenSource; // Must be private or Dispose will not function properly.
+        private Func<IPAddress, int, Socket> tryOpenSocket;
+        private TaskCompletionSource<bool> disposed = new TaskCompletionSource<bool>();
+
+        private Socket socket;
+        private IPAddress host;
+        private int port;
+
+        /// <summary>
+        /// Event that is invoked when reconnecting after a TCP session is dropped fails.
+        /// </summary>
+        public event Action<Exception> LoggingFailureHandler = (ex) => { };
+
+        /// <summary>
+        /// Construct a TCP socket writer that writes to the given host and port.
+        /// </summary>
+        /// <param name="host">IPAddress of the host to open a TCP socket to.</param>
+        /// <param name="port">TCP port to use on the target host.</param>
+        /// <param name="policy">A TcpConnectionPolicy object defining reconnect behavior.</param>
+        /// <param name="maxQueueSize">The maximum number of log entries to queue before starting to drop entries.</param>
+        /// <param name="progress">An IProgress object that reports when the queue of entries to be written reaches empty or there is
+        /// a reconnection failure. This is used for testing purposes only.</param>
+        public TcpSocketWriter(IPAddress host, int port, ITcpReconnectionPolicy policy,
+            int maxQueueSize, Func<IPAddress, int, Socket> connect = null)
+        {
+            this.host = host;
+            this.port = port;
+            this.reconnectPolicy = policy;
+            this.eventQueue = new FixedSizeQueue<string>(maxQueueSize);
+            this.tokenSource = new CancellationTokenSource();
+
+            if (connect == null)
+            {
+                this.tryOpenSocket = (h, p) =>
+                {
+                    try
+                    {
+                        var socket = new Socket(SocketType.Stream, ProtocolType.Tcp);
+                        socket.Connect(host, port);
+                        return socket;
+                    }
+                    catch (SocketException e)
+                    {
+                        LoggingFailureHandler(e);
+                        throw;
+                    }
+                };
+            }
+            else
+            {
+                this.tryOpenSocket = (h, p) =>
+                {
+                    try
+                    {
+                        return connect(h, p);
+                    }
+                    catch (SocketException e)
+                    {
+                        LoggingFailureHandler(e);
+                        throw;
+                    }
+                };
+            }
+
+            var threadReady = new TaskCompletionSource<bool>();
+
+            queueListener = new Thread(() =>
+            {
+                try
+                {
+                    this.socket = this.reconnectPolicy.Connect(tryOpenSocket, host, port, tokenSource.Token);
+                    threadReady.SetResult(true); // Signal the calling thread that we are ready.
+
+                    string entry = null;
+                    while (this.socket != null) // null indicates that the thread has been cancelled and cleaned up.
+                    {
+                        if (tokenSource.Token.IsCancellationRequested)
+                        {
+                            eventQueue.CompleteAdding();
+                            // Post-condition: no further items will be added to the queue, so there will be a finite number of items to handle.
+                            while (eventQueue.Count > 0)
+                            {
+                                entry = eventQueue.Dequeue();
+                                try
+                                {
+                                    this.socket.Send(Encoding.UTF8.GetBytes(entry));
+                                }
+                                catch (SocketException ex)
+                                {
+                                    LoggingFailureHandler(ex);
+                                }
+                            }
+                            break;
+                        }
+                        else if (entry == null)
+                        {
+                            entry = eventQueue.Dequeue(tokenSource.Token);
+                        }
+                        else if (entry != null)
+                        {
+                            try
+                            {
+                                if (this.socket.Send(Encoding.UTF8.GetBytes(entry)) != -1)
+                                {
+                                    entry = null;
+                                }
+                            }
+                            catch (SocketException ex)
+                            {
+                                LoggingFailureHandler(ex);
+                                this.socket = this.reconnectPolicy.Connect(tryOpenSocket, host, port, tokenSource.Token);
+                            }
+                        }
+                    }
+                }
+                catch (Exception e)
+                {
+                    LoggingFailureHandler(e);
+                }
+                finally
+                {
+                    if (socket != null)
+                    {
+                        socket.Close();
+                        socket.Dispose();
+                    }
+
+                    disposed.SetResult(true);
+                }
+            });
+            queueListener.IsBackground = true; // Prevent the thread from blocking the process from exiting.
+            queueListener.Start();
+            threadReady.Task.Wait();
+        }
+
+        public void Dispose()
+        {
+            // The following operations are idempotent. Issue a cancellation to tell the
+            // writer thread to stop the queue from accepting entries and write what it has
+            // before cleaning up, then wait until that cleanup is finished.
+            this.tokenSource.Cancel();
+            Task.Run(async () => await disposed.Task).Wait();
+        }
+
+        /// <summary>
+        /// Push a string onto the queue to be written.
+        /// </summary>
+        /// <param name="entry">The string to be written to the TCP socket.</param>
+        public void Enqueue(string entry)
+        {
+            this.eventQueue.Enqueue(entry);
+        }
+    }
+}
+

--- a/src/Serilog.Sinks.UDP/Serilog.Sinks.Splunk.UDP.csproj
+++ b/src/Serilog.Sinks.UDP/Serilog.Sinks.Splunk.UDP.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <Import Project="../common.props" />
-  
+
   <PropertyGroup>
     <Description>The Splunk UDP Sink for Serilog</Description>
     <TargetFrameworks>netstandard2.1;netstandard2.0</TargetFrameworks>
@@ -16,6 +16,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Serilog.Sinks.Splunk" Version="4.0.0" />
+    <ProjectReference Include="..\Serilog.Sinks.Splunk\Serilog.Sinks.Splunk.csproj" />
   </ItemGroup>
 </Project>

--- a/src/Serilog.Sinks.UDP/Serilog.Sinks.Splunk.UDP.csproj
+++ b/src/Serilog.Sinks.UDP/Serilog.Sinks.Splunk.UDP.csproj
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <Description>The Splunk UDP Sink for Serilog</Description>
-    <TargetFrameworks>netstandard2.1;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;netstandard2.0;net6.0;net8.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>Serilog.Sinks.Splunk.UDP</AssemblyName>
     <PackageId>Serilog.Sinks.Splunk.UDP</PackageId>

--- a/src/Serilog.Sinks.UDP/Serilog.Sinks.Splunk.UDP.csproj
+++ b/src/Serilog.Sinks.UDP/Serilog.Sinks.Splunk.UDP.csproj
@@ -9,7 +9,7 @@
     <AssemblyName>Serilog.Sinks.Splunk.UDP</AssemblyName>
     <PackageId>Serilog.Sinks.Splunk.UDP</PackageId>
     <PackageTags>serilog;splunk;logging;udp</PackageTags>
-    <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
+    <PublicSign Condition=" '$(Configuration)' == 'Debug' ">true</PublicSign>
     <AssemblyOriginatorKeyFile>../../assets/Serilog.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
     <IsPackable>true</IsPackable>

--- a/test/Serilog.Sinks.Splunk.TCP.Tests/Properties/launchSettings.json
+++ b/test/Serilog.Sinks.Splunk.TCP.Tests/Properties/launchSettings.json
@@ -1,0 +1,11 @@
+{
+  "profiles": {
+    "test": {
+      "commandName": "test"
+    },
+    "test-dnxcore50": {
+      "commandName": "test",
+      "sdkVersion": "dnx-coreclr-win-x86.1.0.0-rc1-final"
+    }
+  }
+}

--- a/test/Serilog.Sinks.Splunk.TCP.Tests/Serilog.Sinks.Splunk.TCP.Tests.csproj
+++ b/test/Serilog.Sinks.Splunk.TCP.Tests/Serilog.Sinks.Splunk.TCP.Tests.csproj
@@ -1,0 +1,33 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net462</TargetFramework>
+    <AssemblyName>Serilog.Sinks.Splunk.Tests</AssemblyName>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <IsPackable>false</IsPackable>
+    <LangVersion>latest</LangVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="xunit" Version="2.7.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.7">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Serilog.Sinks.TCP\Serilog.Sinks.Splunk.TCP.csproj" />
+  </ItemGroup>
+</Project>

--- a/test/Serilog.Sinks.Splunk.TCP.Tests/TCPCollectorTests.cs
+++ b/test/Serilog.Sinks.Splunk.TCP.Tests/TCPCollectorTests.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.NetworkInformation;
+using System.Net.Sockets;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Serilog.Events;
+using Xunit;
+
+namespace Serilog.Sinks.Splunk.TCP.Tests;
+
+public class TCPCollectorTests
+{
+    [Fact]
+    public void LoggerExtensionTest()
+    {
+        using (var TestEnvironment = new TestEnvironment())
+        {
+            var log = new LoggerConfiguration()
+                .WriteTo.SplunkViaTcp(
+                    new Serilog.Sinks.Splunk.SplunkTcpSinkConnectionInfo("127.0.0.1", 10001),
+                    restrictedToMinimumLevel: LevelAlias.Minimum,
+                    formatProvider: null,
+                    renderTemplate: true)
+                .CreateLogger();
+
+            log.Information("Hello World");
+        }
+    }
+
+}
+
+class TestEnvironment : IDisposable
+{
+    TcpListener TcpServer;
+
+    readonly public int TcpServerAddress;
+
+    public TestEnvironment(int TcpServerAddress = 10001)
+    {
+        this.TcpServerAddress = TcpServerAddress;
+
+        TcpServer = new TcpListener(IPAddress.Loopback, TcpServerAddress);
+
+        TcpServer.Start();
+    }
+
+    public void Dispose()
+    {
+        TcpServer.Stop();
+    }
+}


### PR DESCRIPTION
- Embedd sources as `Splunk.Logging.Common.Core` is not signed upstream
- netstandard2.1 is not supported by `Splunk.Logging.Common.Core`
- Add a TCP socket unit test to ensure assembly can load

Fixes #155