### PR TITLE
Fix for #205 allow collector path in host url

### DIFF
--- a/src/Serilog.Sinks.Splunk/ConfigurationDefaults.cs
+++ b/src/Serilog.Sinks.Splunk/ConfigurationDefaults.cs
@@ -14,5 +14,6 @@
         /// https://docs.splunk.com/Documentation/Splunk/9.1.0/Data/UsetheHTTPEventCollector#Send_data_to_HTTP_Event_Collector_on_Splunk_Enterprise
         /// </remarks>
         internal const string DefaultEventCollectorPath = "services/collector/event";
+        internal const string DefaultCollectorPath = "services/collector";
     }
 }

--- a/src/Serilog.Sinks.Splunk/Sinks/Splunk/EventCollectorRequest.cs
+++ b/src/Serilog.Sinks.Splunk/Sinks/Splunk/EventCollectorRequest.cs
@@ -23,8 +23,7 @@ namespace Serilog.Sinks.Splunk
     {
         internal EventCollectorRequest(string splunkHost, string jsonPayLoad, string uri = ConfigurationDefaults.DefaultEventCollectorPath)
         {
-            var hostUrl = splunkHost.Contains(ConfigurationDefaults.DefaultEventCollectorPath) ||
-                          splunkHost.Contains(ConfigurationDefaults.DefaultCollectorPath)
+            var hostUrl = splunkHost.Contains(ConfigurationDefaults.DefaultCollectorPath)
                 ? splunkHost
                 : $"{splunkHost.TrimEnd('/')}/{uri.TrimStart('/').TrimEnd('/')}";
            

--- a/src/Serilog.Sinks.Splunk/Sinks/Splunk/EventCollectorRequest.cs
+++ b/src/Serilog.Sinks.Splunk/Sinks/Splunk/EventCollectorRequest.cs
@@ -1,4 +1,4 @@
-// Copyright 2016 Serilog Contributors
+﻿// Copyright 2016 Serilog Contributors
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -23,7 +23,8 @@ namespace Serilog.Sinks.Splunk
     {
         internal EventCollectorRequest(string splunkHost, string jsonPayLoad, string uri = ConfigurationDefaults.DefaultEventCollectorPath)
         {
-            var hostUrl = splunkHost.Contains(ConfigurationDefaults.DefaultEventCollectorPath)
+            var hostUrl = splunkHost.Contains(ConfigurationDefaults.DefaultEventCollectorPath) ||
+                          splunkHost.Contains(ConfigurationDefaults.DefaultCollectorPath)
                 ? splunkHost
                 : $"{splunkHost.TrimEnd('/')}/{uri.TrimStart('/').TrimEnd('/')}";
            


### PR DESCRIPTION
This should allow for the previous collector path in the host url.