### PR TITLE
Add dotnet 9.0 support

### DIFF
--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 8.0.x
+          dotnet-version: 9.0.x
       - name: Build and Publish
         env:
           DOTNET_CLI_TELEMETRY_OPTOUT: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 8.0.x
+          dotnet-version: 9.0.x
       - name: Build and Publish
         env:
           DOTNET_CLI_TELEMETRY_OPTOUT: true

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 8.0.x
+        dotnet-version: 9.0.x
 
     - name: Restore Dependencies
       run: dotnet restore serilog-sinks-splunk.sln

--- a/src/Serilog.Sinks.Splunk/Serilog.Sinks.Splunk.csproj
+++ b/src/Serilog.Sinks.Splunk/Serilog.Sinks.Splunk.csproj
@@ -4,7 +4,7 @@
   
   <PropertyGroup>
     <Description>The Splunk Sink for Serilog</Description>
-    <TargetFrameworks>netstandard2.1;netstandard2.0;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;netstandard2.0;net6.0;net8.0;net9.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>Serilog.Sinks.Splunk</AssemblyName>
     <PackageId>Serilog.Sinks.Splunk</PackageId>

--- a/src/Serilog.Sinks.TCP/Serilog.Sinks.Splunk.TCP.csproj
+++ b/src/Serilog.Sinks.TCP/Serilog.Sinks.Splunk.TCP.csproj
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <Description>The Splunk TCP Sink for Serilog</Description>
-    <TargetFrameworks>netstandard2.1;netstandard2.0;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;netstandard2.0;net6.0;net8.0;net9.0</TargetFrameworks>
     <AssemblyName>Serilog.Sinks.Splunk.TCP</AssemblyName>
     <PackageId>Serilog.Sinks.Splunk.TCP</PackageId>
     <PackageTags>serilog;splunk;logging;tcp</PackageTags>

--- a/src/Serilog.Sinks.UDP/Serilog.Sinks.Splunk.UDP.csproj
+++ b/src/Serilog.Sinks.UDP/Serilog.Sinks.Splunk.UDP.csproj
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <Description>The Splunk UDP Sink for Serilog</Description>
-    <TargetFrameworks>netstandard2.1;netstandard2.0;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;netstandard2.0;net6.0;net8.0;net9.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>Serilog.Sinks.Splunk.UDP</AssemblyName>
     <PackageId>Serilog.Sinks.Splunk.UDP</PackageId>


### PR DESCRIPTION
This simply adds support for net9.0 in the nuget package.

NOTE: CodeQL does not have net9.0 support yet. This will stay pre-release until that dependency is met.